### PR TITLE
Properly supporting multiple dbUris

### DIFF
--- a/lib/Service.js
+++ b/lib/Service.js
@@ -795,7 +795,7 @@ var Service = oo({
       self.logInfo("Service initializing connection to db: " +
                    self._secureMongoUriString(uri))
       try {
-        self.db = connect(uri)
+        return connect(uri)
       } catch(e) {
         throw new Error("Could not connect to " +
                         self._secureMongoUriString(uri) +
@@ -805,14 +805,14 @@ var Service = oo({
 
     // initialize dbs
     if (this.dbUri) {
-      makeConnection(this.dbUri)
+      this.db = makeConnection(this.dbUri)
     }
 
     // initialize dbs
     if (this.dbUris) {
       this.dbs = {}
       for (var dbname in this.dbUris) {
-        makeConnection(this.dbUris[dbname])
+        this.dbs[dbname] = makeConnection(this.dbUris[dbname])
       }
     }
   },


### PR DESCRIPTION
Fixed a bug where the dbUris property wasn't being correctly processed.  Instead of populating the dbs map, it was just repeatedly setting this.db over and over again, resulting in this.dbs being empty and this.db pointing to the last connection created.