### PR TITLE
Add example changes for domain usage

### DIFF
--- a/docs/ref/carbond.Collection.rst
+++ b/docs/ref/carbond.Collection.rst
@@ -1,12 +1,12 @@
+.. js:class:: Collection()
+    :heading:
+
 ==================
 carbond.Collection
 ==================
 
-.. js:class:: Collection()
-    :hidden:
-
-Carbond ``Collection``\ s provide a high-level abstraction for defining ``Endpoint``\ s that behave like a collection of 
-resources. When you define a ``Collection`` you define the following methods:
+Carbond :class:`Collection`\ s provide a high-level abstraction for defining :class:`Endpoint`\ s that behave like a collection of 
+resources. When you define a :class:`Collection` you define the following methods:
 
 - ``insert(obj, reqCtx)``
 - ``find(query, options, reqCtx)``
@@ -16,7 +16,7 @@ resources. When you define a ``Collection`` you define the following methods:
 - ``updateObject(id, reqCtx)``
 - ``removeObject(id, reqCtx)``
 
-Which results in the following tree of ``Endpoints`` and ``Operations``:
+Which results in the following tree of :class:`Endpoints` and :class:`Operations`:
 
 - ``/<collection>``
 
@@ -61,15 +61,29 @@ Configuration
 Properties
 ==========
 
-- ``path`` (read-only): The path to which this ``Collection`` is bound. The path can contain variable patterns (e.g. ``'orgs/:id/members'``). The ``path`` property is not configured directly on ``Collection`` objects but are specified as lvals in enclosing definitions of endpoints such as in an ``ObjectServer`` or a parent ``Endpoint`` object. When retrieved the value of this property will be the absolute path of the endpoint from ``/``. 
+.. js:class:: Collection()
+    :noindex:
+    :hidden:
 
-- ``parent`` (read-only): The parent ``Endpoint`` of this ``Collection``.
+    .. js:attribute:: path
 
-- ``objectserver`` (read-only): The ``ObjectServer`` to which this endpoint belongs.
+        (read-only): The path to which this :class:`Collection` is bound. The path can contain variable patterns (e.g. ``'orgs/:id/members'``). The :attr:`path` property is not configured directly on :class:`Collection` objects but are specified as lvals in enclosing definitions of endpoints such as in an :class:`ObjectServer` or a parent :class:`Endpoint` object. When retrieved the value of this property will be the absolute path of the endpoint from ``/``.
 
-- ``parameters``: A mapping of parameter names to ``OperationParameter`` objects. Parameters defined for an ``Endpoint`` are inherited by all operations of this ``Endpoint`` as well as by all child ``Endpoint``\ s of this ``Endpoint``.
+    .. js:attribute:: parent
 
-- ``endpoints``: A set of child ``Endpoint`` definitions. This is an object whose keys are path strings and values are instances of ``Endpoint``. Each path key will be interpreted as relative to this ``Endpoint``\ s ``path`` property. 
+        (read-only): The parent :class:`Endpoint` of this :class:`Collection`.
+
+    .. js:attribute:: objectserver
+
+        (read-only): The :class:`ObjectServer` to which this endpoint belongs.
+
+    .. js:attribute:: parameters
+
+        A mapping of parameter names to :class:`OperationParameter` objects. Parameters defined for an :class:`Endpoint` are inherited by all operations of this :class:`Endpoint` as well as by all child :class:`Endpoint`\ s of this :class:`Endpoint`.
+
+    .. js:attribute:: endpoints
+
+        A set of child :class:`Endpoint` definitions. This is an object whose keys are path strings and values are instances of :class:`Endpoint`. Each path key will be interpreted as relative to this :class:`Endpoint`\ s :attr:`path` property.
 
 Methods
 =======


### PR DESCRIPTION
This example updates the carbond.Collection docs to use the javascript domain
instead of manually forming these lists.