### PR TITLE
Support configurable flavor-specific defaults for gen-static-docs options

### DIFF
--- a/lib/Service.js
+++ b/lib/Service.js
@@ -292,6 +292,11 @@ var Service = oo({
 
     // swagger / docs
     this.generateOptionsMethodsInDocs = false
+    this.defaultFlavorOptions = {
+      "github-flavored-markdown": {},
+      "api-blueprint": {},
+      "aglio": {}
+    }
 
     // logging
     this._bunyanLog = undefined

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -292,7 +292,7 @@ var Service = oo({
 
     // swagger / docs
     this.generateOptionsMethodsInDocs = false
-    this.defaultFlavorOptions = {
+    this.defaultDocgenOptions = {
       "github-flavored-markdown": {},
       "api-blueprint": {},
       "aglio": {}

--- a/lib/docgen/Aglio.js
+++ b/lib/docgen/Aglio.js
@@ -87,7 +87,9 @@ var AglioGenerator = oo({
     }
     var generator = StaticDocumentationGenerator.createGenerator('api-blueprint', this._service)
     var blueprint = generator.generateBlueprint()
-    var html = aglio.sync.render(blueprint, this._parseOptions(options))
+    var parsedOptions = _.get(this._service, "defaultFlavorOptions.aglio") || {}
+    parsedOptions = _.assign(parsedOptions, this._parseOptions(options) || {})
+    var html = aglio.sync.render(blueprint, parsedOptions)
     docsPath = docsPath || "api.html"
     if (docsPath === 'stdout') {
       console.log(html)

--- a/lib/docgen/Aglio.js
+++ b/lib/docgen/Aglio.js
@@ -87,7 +87,7 @@ var AglioGenerator = oo({
     }
     var generator = StaticDocumentationGenerator.createGenerator('api-blueprint', this._service)
     var blueprint = generator.generateBlueprint()
-    var parsedOptions = _.get(this._service, "defaultFlavorOptions.aglio") || {}
+    var parsedOptions = _.get(this._service, "defaultDocgenOptions.aglio") || {}
     parsedOptions = _.assign(parsedOptions, this._parseOptions(options) || {})
     var html = aglio.sync.render(blueprint, parsedOptions)
     docsPath = docsPath || "api.html"

--- a/lib/docgen/GitHubMarkDown.js
+++ b/lib/docgen/GitHubMarkDown.js
@@ -102,7 +102,7 @@ var GHMDGenerator = oo({
    */
   generateDocs: function(docsPath, options) {
     var descriptor = this._generateDescriptor()
-    var parsedOptions = _.get(this._service, "defaultFlavorOptions.github-flavored-markdown") || {}
+    var parsedOptions = _.get(this._service, "defaultDocgenOptions.github-flavored-markdown") || {}
     parsedOptions = _.assign(parsedOptions, this._parseOptions(options) || {})
 
     if (parsedOptions['single-page']) {

--- a/lib/docgen/GitHubMarkDown.js
+++ b/lib/docgen/GitHubMarkDown.js
@@ -102,9 +102,10 @@ var GHMDGenerator = oo({
    */
   generateDocs: function(docsPath, options) {
     var descriptor = this._generateDescriptor()
-    var options = this._parseOptions(options)
+    var parsedOptions = _.get(this._service, "defaultFlavorOptions.github-flavored-markdown") || {}
+    parsedOptions = _.assign(parsedOptions, this._parseOptions(options) || {})
 
-    if (options['single-page']) {
+    if (parsedOptions['single-page']) {
       this._generateSinglePage(descriptor, docsPath)
     }
     else {


### PR DESCRIPTION
This change adds the ability to configure flavor-specific defaults for the options that can be passed to gen-static-docs.  For example, if you want Aglio-flavored documentation for your service to be full width by default, you'd add this to your service:

```
defaultFlavorOptions: {
  aglio: {
    themeFullWidth: true
  }
}
```

This is most useful if you've created custom themes and styles that are optimized for your service's documentation.  For example:

```
defaultFlavorOptions: {
  aglio: {
    themeStyle: "./doc/custom-style.less",
    themeVariables: "./doc/custom-variables.less"
  }
}
```

With this in place, users can simply run gen-static-docs with no options and your custom styles will be used. For example:

```
$ node ./lib/MyService.js gen-static-docs --flavor aglio
```

Instead of:
```
$ node ./lib/MyService.js gen-static-docs --flavor aglio --option "themeStyle:./doc/custom-style.less,themeVariables:./doc/custom-variables.less"
```