### PR TITLE
Fix throwUnauthenticated sending default message

### DIFF
--- a/lib/security/Authenticator.js
+++ b/lib/security/Authenticator.js
@@ -43,8 +43,10 @@ module.exports = oo({
     // XXX: we need to include the `WWW-Athenticate` response header when
     //      authentication fails. see http://www.ietf.org/rfc/rfc2617.txt
     //      section 3.2.1
-    throw new this.service.errors.Unauthorized(
-      _.isUndefined(msg) ? msg : DEFAULT_UNAUTHENTICATED_ERROR)
+
+    var errorMsg = _.isUndefined(msg) ? DEFAULT_UNAUTHENTICATED_ERROR : msg
+
+    throw new this.service.errors.Unauthorized(errorMsg)
   },
 
   /*****************************************************************************


### PR DESCRIPTION
throwUnauthenticated wasn't sending the default message when no argument was passed. When an argument was passed, it was sending the default message instead.