### PR TITLE
Renames issue 288

### DIFF
--- a/docs/code-frags/counter-col/lib/CounterCol.js
+++ b/docs/code-frags/counter-col/lib/CounterCol.js
@@ -369,7 +369,7 @@ __(function() {
       mongoCounterBasic: o({
         _type: carbon.carbond.collections.Collection,
         enabled: {'*': true},
-        collection: {
+        collectionName: {
           $property: {
             get: function() {
               return this.service.db.getCollection('mongo-counter')

--- a/docs/code-frags/standalone-examples/ServiceExternalACLExample.js
+++ b/docs/code-frags/standalone-examples/ServiceExternalACLExample.js
@@ -18,7 +18,7 @@ __(function() {
     endpoints: {
       hello: o({
         _type: carbon.carbond.mongodb.MongoDBCollection,
-        collection: 'hello',
+        collectionName: 'hello',
         enabled: {'*': true},
         acl: _o('./MyAcl')
       })

--- a/docs/code-frags/standalone-examples/ServiceSimpleAuthorizationExample.js
+++ b/docs/code-frags/standalone-examples/ServiceSimpleAuthorizationExample.js
@@ -91,7 +91,7 @@ __(function() {
       endpoints: {
         hello: o({
           _type: carbon.carbond.mongodb.MongoDBCollection,
-          collection: 'hello',
+          collectionName: 'hello',
           enabled: {'*': true},
           acl: o({
             _type: carbon.carbond.security.CollectionAcl,

--- a/docs/guide/collections/collection-operation-configuration.rst
+++ b/docs/guide/collections/collection-operation-configuration.rst
@@ -14,7 +14,7 @@ they were initialized as ``{}`` using the appropriate
 :js:attr:`~carbond.collections.Collection.insertConfig` is left as ``undefined``,
 it will be instantiated as ``o({}, this.InsertConfigClass)``, where
 ``this.InsertConfigClass`` is a class member that allows subclasses of
-:js:class:`carbond.collection.Collection` to override the default config class).
+:js:class:`~carbond.collections.Collection` to override the default config class).
 Operations should be configured with the following properties:
 
 - :js:attr:`~carbond.collections.Collection.insertConfig`
@@ -104,10 +104,10 @@ The :js:class:`~carbond.collections.InsertConfig` class is the base ``insert``
 operation config class and the default for
 :js:class:`~carbond.collections.Collection`. It can be used to configure whether
 or not inserted objects are returned
-(:js:attr:`~carbond.collection.InsertConfig.returnsInsertedObjects`) in the
+(:js:attr:`~carbond.collections.InsertConfig.returnsInsertedObjects`) in the
 response body and to define a schema separate from the collection level schema
 that will be used to verify incoming objects
-(:js:attr:`~carbond.collection.InsertConfig.insertSchema`).
+(:js:attr:`~carbond.collections.InsertConfig.insertSchema`).
 
 .. code-block:: js
 
@@ -200,7 +200,7 @@ objects saved are returned in the response.
 Note, unlike :js:attr:`~carbond.collections.InsertConfig.insertSchema`, it is
 necessary to specify the ID parameter (``_id`` in this case) on ``saveSchema``.
 Note, it should have the same name as
-:js:attr:`~carbond.collections.Collection.idParameter` or an error will be thrown
+:js:attr:`~carbond.collections.Collection.idParameterName` or an error will be thrown
 on initialization.
 
 UpdateConfig

--- a/docs/guide/collections/collection-operation-handlers.rst
+++ b/docs/guide/collections/collection-operation-handlers.rst
@@ -123,8 +123,8 @@ indicating the subset of objects to return (e.g., ``options.skip`` and
 
 If ID queries are supported (note, ID query support is necessary when supporting
 bulk inserts), a query parameter by the same name as
-:js:attr:`~carbond.collections.Collection.idParameter` will be added and
-ultimately passed to the handler via ``options[this.idParameter]``.
+:js:attr:`~carbond.collections.Collection.idParameterName` will be added and
+ultimately passed to the handler via ``options[this.idParameterName]``.
 
 The following in-memory cache example accommodates both of these options:
 

--- a/docs/guide/collections/collection-operation-hooks.rst
+++ b/docs/guide/collections/collection-operation-hooks.rst
@@ -65,7 +65,7 @@ see a different object than user "bar" when making a request to
     preFindObjectOperation(config, req, res) {
       var options = Collection.prototype.preFindObjectOperation.call(this, config, req, res)
       var idPrefix = getUserIdPrefix(req.user)
-      options[this.idPathParameter] = idPrefix + '-' + options[this.idPathParameter]
+      options[this.idPathParameterName] = idPrefix + '-' + options[this.idPathParameterName]
       return options
     }
 

--- a/docs/guide/collections/collection-operation-rest-interface.rst
+++ b/docs/guide/collections/collection-operation-rest-interface.rst
@@ -87,14 +87,14 @@ In the following tables, ``bulk`` will refer to requests whose body is an
 GET /<collection>
 -----------------
 
-.. list-table:: Request Parameters (note, ``<idParameter>`` is configurable on ``Collection``)
+.. list-table:: Request Parameters (note, ``<idParameterName>`` is configurable on ``Collection``)
     :header-rows: 1
     :class: collection-rest-table
 
     * - Name
       - Location
       - Description
-    * - <:js:attr:`~carbond.collections.Collection.idParameter`>
+    * - <:js:attr:`~carbond.collections.Collection.idParameterName`>
       - query
       - Contains the IDs of objects to be retrieved. This parameter is only
         present if :js:attr:`~carbond.collections.FindConfig.supportsIdQuery` is
@@ -249,14 +249,14 @@ DELETE /<collection>
 GET /<collection>/:<id>
 -----------------------
 
-.. list-table:: Request Parameters (note, ``idPathParameter`` is configurable on ``Collection``)
+.. list-table:: Request Parameters (note, ``idPathParameterName`` is configurable on ``Collection``)
     :header-rows: 1
     :class: collection-rest-table
 
     * - Name
       - Location
       - Description
-    * - <:js:attr:`~carbond.collections.Collection.idPathParameter`>
+    * - <:js:attr:`~carbond.collections.Collection.idPathParameterName`>
       - path
       - The ID component of the Collection object URL. Identifies a specific
         object in the Collection.
@@ -269,7 +269,7 @@ GET /<collection>/:<id>
       - Description
     * - ``200``
       - The response body will contain the object whose ID matches the value
-        passed in <:js:attr:`~carbond.collections.Collection.idPathParameter`>
+        passed in <:js:attr:`~carbond.collections.Collection.idPathParameterName`>
     * - ``400``
       - The request was malformed
     * - ``403``
@@ -282,14 +282,14 @@ GET /<collection>/:<id>
 PUT /<collection>/:<id>
 -----------------------
 
-.. list-table:: Request Parameters (note, ``idPathParameter`` is configurable on ``Collection``)
+.. list-table:: Request Parameters (note, ``idPathParameterName`` is configurable on ``Collection``)
     :header-rows: 1
     :class: collection-rest-table
 
     * - Name
       - Location
       - Description
-    * - <:js:attr:`~carbond.collections.Collection.idPathParameter`>
+    * - <:js:attr:`~carbond.collections.Collection.idPathParameterName`>
       - path
       - The ID component of the Collection object URL. Identifies a specific
         object in the Collection.
@@ -348,14 +348,14 @@ PUT /<collection>/:<id>
 PATCH /<collection>/:<id>
 -------------------------
 
-.. list-table:: Request Parameters (note, ``idPathParameter`` is configurable on ``Collection``)
+.. list-table:: Request Parameters (note, ``idPathParameterName`` is configurable on ``Collection``)
     :header-rows: 1
     :class: collection-rest-table
 
     * - Name
       - Location
       - Description
-    * - <:js:attr:`~carbond.collections.Collection.idPathParameter`>
+    * - <:js:attr:`~carbond.collections.Collection.idPathParameterName`>
       - path
       - The ID component of the Collection object URL. Identifies a specific
         object in the Collection.
@@ -408,14 +408,14 @@ PATCH /<collection>/:<id>
 DELETE /<collection>/:<id>
 --------------------------
 
-.. list-table:: Request Parameters (note, ``idPathParameter`` is configurable on ``Collection``)
+.. list-table:: Request Parameters (note, ``idPathParameterName`` is configurable on ``Collection``)
     :header-rows: 1
     :class: collection-rest-table
 
     * - Name
       - Location
       - Description
-    * - <:js:attr:`~carbond.collections.Collection.idPathParameter`>
+    * - <:js:attr:`~carbond.collections.Collection.idPathParameterName`>
       - path
       - The ID component of the Collection object URL. Identifies a specific
         object in the Collection.

--- a/docs/guide/collections/collection-operation-rest-interface.rst
+++ b/docs/guide/collections/collection-operation-rest-interface.rst
@@ -52,10 +52,10 @@ In the following tables, ``bulk`` will refer to requests whose body is an
     * - ``Location``
       - ``object``
       - Contains the object URL
-    * - :js:attr:`~carbond.collections.Collection.idHeader`
+    * - :js:attr:`~carbond.collections.Collection.idHeaderName`
       - ``bulk``
       - Contains the EJSON serialized IDs of the inserted objects
-    * - :js:attr:`~carbond.collections.Collection.idHeader`
+    * - :js:attr:`~carbond.collections.Collection.idHeaderName`
       - ``object``
       - Contains the EJSON serialized ID of the inserted object
 
@@ -201,7 +201,7 @@ PATCH /<collection>
     * - ``Location``
       - Contains the URL to retrieve all upserted objects in ID query format
         (see: `FindConfig`_)
-    * - :js:attr:`~carbond.collections.Collection.idHeader`
+    * - :js:attr:`~carbond.collections.Collection.idHeaderName`
       - Contains the EJSON serialized IDs of the upserted objects
 
 .. list-table:: Status Codes
@@ -306,7 +306,7 @@ PUT /<collection>/:<id>
     * - ``Location``
       - Contains the URL of the new object. Note, this is only possible if
         :js:attr:`~carbond.collections.SaveObjectConfig.supportsUpsert` is ``true``.
-    * - :js:attr:`~carbond.collections.Collection.idHeader`
+    * - :js:attr:`~carbond.collections.Collection.idHeaderName`
       - Contains the EJSON serialized ID of the new object. Note, this is only
         possible if
         :js:attr:`~carbond.collections.SaveObjectConfig.supportsUpsert` is ``true``.
@@ -376,7 +376,7 @@ PATCH /<collection>/:<id>
       - Description
     * - ``Location``
       - Contains the URL of the upserted object
-    * - :js:attr:`~carbond.collections.Collection.idHeader`
+    * - :js:attr:`~carbond.collections.Collection.idHeaderName`
       - Contains the EJSON serialized ID of the upserted object
 
 .. list-table:: Status Codes

--- a/docs/guide/collections/index.rst
+++ b/docs/guide/collections/index.rst
@@ -156,7 +156,7 @@ The base ``Collection`` configuration consists of a few properties:
 * :js:attr:`~carbond.collections.Collection.idParameterName` - this is the name
   of the ID property of a Collection object (e.g. ``{<idParameterName>: "foo",
   "bar": "baz"}``).
-* :js:attr:`~carbond.collections.Collection.idHeader` - this is the name of the
+* :js:attr:`~carbond.collections.Collection.idHeaderName` - this is the name of the
   HTTP response header that will contain the EJSON serialized object ID or IDs
   when objects are created in the Collection.
 

--- a/docs/guide/collections/index.rst
+++ b/docs/guide/collections/index.rst
@@ -139,12 +139,26 @@ which may have implications for certain Collection operations, and
 The base ``Collection`` configuration consists of a few properties:
 
 * :js:attr:`~carbond.collections.Collection.enabled` - see `Enabling / Disabling Operations`_
-* :js:attr:`~carbond.collections.Collection.schema` - this is the schema for all objects in the Collection. It must be of type ``object`` and contain an ID property whose name is the same as the value of :js:attr:`~carbond.collections.Collection.idParameter`.
-* :js:attr:`~carbond.collections.Collection.example` - this is an example object in the Collection and is used for documentation.
-* :js:attr:`~carbond.collections.Collection.idGenerator` - if present, this must be an object with at least one method: ``generateId``.  This method will be passed the :js:class:`~carbond.collections.Collection` instance along with the current :js:class:`~carbond.Request` object and should return a suitable ID for the object being inserted on ``insert`` or ``insertObject``.
-* :js:attr:`~carbond.collections.Collection.idPathParameter`- this is the name of the path parameter used to capture an object ID for object specific endpoints (e.g. ``/<someCollectionName>/:<idPathParameter>``).
-* :js:attr:`~carbond.collections.Collection.idParameter` - this is the name of the ID property of a Collection object (e.g. ``{<idParameter>: "foo", "bar": "baz"}``).
-* :js:attr:`~carbond.collections.Collection.idHeader` - this is the name of the HTTP response header that will contain the EJSON serialized object ID or IDs when objects are created in the Collection.
+* :js:attr:`~carbond.collections.Collection.schema` - this is the schema for all
+  objects in the Collection. It must be of type ``object`` and contain an ID
+  property whose name is the same as the value of
+  :js:attr:`~carbond.collections.Collection.idParameterName`.
+* :js:attr:`~carbond.collections.Collection.example` - this is an example object
+  in the Collection and is used for documentation.
+* :js:attr:`~carbond.collections.Collection.idGenerator` - if present, this must
+  be an object with at least one method: ``generateId``.  This method will be
+  passed the :js:class:`~carbond.collections.Collection` instance along with the
+  current :js:class:`~carbond.Request` object and should return a suitable ID
+  for the object being inserted on ``insert`` or ``insertObject``.
+* :js:attr:`~carbond.collections.Collection.idPathParameterName`- this is the
+  name of the path parameter used to capture an object ID for object specific
+  endpoints (e.g. ``/<someCollectionName>/:<idPathParameterName>``).
+* :js:attr:`~carbond.collections.Collection.idParameterName` - this is the name
+  of the ID property of a Collection object (e.g. ``{<idParameterName>: "foo",
+  "bar": "baz"}``).
+* :js:attr:`~carbond.collections.Collection.idHeader` - this is the name of the
+  HTTP response header that will contain the EJSON serialized object ID or IDs
+  when objects are created in the Collection.
 
 Note: most of these properties already have sane defaults (see
 the :js:class:`~carbond.collections.Collection` class reference for more details).

--- a/docs/guide/collections/mongodb-collection-operation-config-class.rst
+++ b/docs/guide/collections/mongodb-collection-operation-config-class.rst
@@ -3,7 +3,7 @@ MongoDBCollection Operation Configuration
 =========================================
 
 The :js:class:`~carbond.mongodb.MongoDBCollection` implementation overrides
-:js:class:`~carbond.collection.Collection`\ 's configuration class members with
+:js:class:`~carbond.collections.Collection`\ 's configuration class members with
 the following classes:
 
 - :js:class:`~carbond.mongodb.MongoDBInsertConfig`

--- a/docs/guide/collections/mongodb-collection.rst
+++ b/docs/guide/collections/mongodb-collection.rst
@@ -21,11 +21,11 @@ MongoDBCollection Configuration
 :js:class:`~carbond.collections.Collection` with the following configuration
 properties:
 
-    :js:attr:`~carbond.mongodb.MongoDBCollection.db`
+    :js:attr:`~carbond.mongodb.MongoDBCollection.dbName`
         This is only necessary if the :js:class:`~carbond.Service` instance
         connects to multiple databases and should be a key in
         :js:attr:`~carbond.Service.dbUris`.
-    :js:attr:`~carbond.mongodb.MongoDBCollection.collection`
+    :js:attr:`~carbond.mongodb.MongoDBCollection.collectionName`
         This is the name of the MongoDB collection that the endpoint will operate
         on.
     :js:attr:`~carbond.mongodb.MongoDBCollection.querySchema`

--- a/docs/guide/operations.rst
+++ b/docs/guide/operations.rst
@@ -15,7 +15,7 @@ Each operation is represented as either:
 - A function of the form ``function(req, res)``.
 - An :js:class:`~carbond.Operation` object. This is a more elaborate definition
   which allows for a description, parameter definitions, and other useful
-  metadata as well as a :js:func:`~carbond.Operation.service`` method of the
+  metadata as well as a :js:func:`~carbond.Operation.handle`` method of the
   form ``function(req, res)``.
 
 When responding to HTTP requests, two styles are supported:

--- a/lib/Endpoint.js
+++ b/lib/Endpoint.js
@@ -164,17 +164,6 @@ module.exports = oo(_.mixin({
   },
 
   /*****************************************************************************
-   * @property {Array.<string>} _frozenProperties
-   * @description The list of properties to freeze after initialization
-   * @readonly
-   */
-  _frozenProperties: [
-    'path',
-    'parent',
-    'service'
-  ],
-
-  /*****************************************************************************
    * @method _initializeOperations
    * @description Initializes all operations defined on this endpoint
    * @returns {undefined}

--- a/lib/Operation.js
+++ b/lib/Operation.js
@@ -1,4 +1,5 @@
 var url = require('url')
+var util = require('util')
 
 var _ = require('lodash')
 
@@ -182,7 +183,7 @@ module.exports = oo(_.mixin({
   },
 
   /*****************************************************************************
-   * @method service
+   * @method handle
    * @description Handles incoming requests, generating the appropriate response.
    *              Responses can be sent by the handler itself or this can be
    *              delegated to the service. If an object is returned, it will be
@@ -200,9 +201,30 @@ module.exports = oo(_.mixin({
    * @param {carbond.Response} res -- The response object
    * @returns {Object|null|undefined}
    * @throws {httperrors.HttpError}
+   * @deprecated Use ``handle`` instead
    */
-  service: function(req, res) {
+  handle: function(req, res) {
     throw new Error('Implement me')
+  },
+
+  /*****************************************************************************
+   * @method service
+   * @description Alias for {@link carbond.Operation.handle}
+   * @param {carbond.Request} req -- The current request object
+   * @param {carbond.Response} res -- The response object
+   * @returns {Object|null|undefined}
+   * @throws {httperrors.HttpError}
+   * @deprecated Use ``handle`` instead
+   */
+  service: {
+    $property: {
+      get: function() {
+        return util.deprecate(this.handle, 'Use "handle" instead of "service"')
+      },
+      set: function(handler) {
+        this.handle = handler
+      }
+    }
   },
 }, _o('./util/mixins/OperationParametersInitializer')))
 

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -41,6 +41,171 @@ var __ = fibers.__(module)
 DEFAULT_ENV = _o('env:NODE_ENV') || 'production'
 
 /***************************************************************************************************
+ * @description Documented on carbond.Service.defaultCmdargs
+ * @constant
+ * @memberof carbond
+ * @ignore
+ */
+DEFAULT_SERVICE_CMDARGS = {
+  'verbosity': {
+    abbr: 'v',
+    metavar: 'VERBOSITY',
+    property: true,
+    choices: ['trace', 'debug', 'info', 'warn', 'error', 'fatal'],
+    help: 'verbosity level (trace | debug | info | warn | error | fatal)',
+  },
+  'start-server': {
+    command: true,
+    default: true,
+    help: 'start the api server',
+    cmdargs: {
+      'port': {
+        abbr: 'p',
+        metavar: 'PORT',
+        property: true,
+        help: 'port'
+      },
+      'hostname': {
+        abbr: 'n',
+        default: '0.0.0.0',   // XXX: this should probably be 127.0.0.1
+        metavar: 'HOSTNAME',
+        property: true,
+        help: 'the hostname to bind'
+      },
+      'dbUri': {
+        abbr: 'd',
+        metavar: 'DB_URI',
+        property: true,
+        help: 'MongoDB connection string'
+      },
+      'cluster': {
+        flag: true,
+        property: true,
+        help: 'use node cluster'
+      },
+      'numClusterWorkers': {
+        full: 'num-cluster-workers',
+        metavar: 'NUM',
+        property: true,
+        default: 0,
+        help: 'fork NUM cluster nodes (default is "0" to fork a worker for each CPU)'
+      },
+      'exitOnClusterWorkerExit': {
+        full: 'exit-on-cluster-worker-exit',
+        property: true,
+        flag: true,
+        help: 'if this flag is set, the master will exit if a work dies, otherwise ' +
+              'a warning will be logged'
+      },
+      'swagger': {
+        flag: true,
+        property: true,
+        help: 'mount swagger endpoints'
+      },
+      'enableBusyLimiter': {
+        full: 'enable-busy-limiter',
+        flag: true,
+        property: true,
+        help: 'send 503 responses when the node process becomes too "busy"'
+      },
+      'fiberPoolSize': {
+        full: 'fiber-pool-size',
+        metavar: 'SIZE',
+        property: true,
+        default: fibers.getFiberPoolSize(),
+        help: 'set the fiber pool size',
+        callback: function(fiberPoolSize) {
+          fiberPoolSize = parseInt(fiberPoolSize)
+          if (!_.isInteger(fiberPoolSize)) {
+            return 'fiber-pool-size must be an integer'
+          } else if (fiberPoolSize <= 0) {
+            return 'fiber-pool-size must be greater than 0'
+          }
+        }
+      },
+      'env': {
+        metavar: 'MODE',
+        property: true,
+        default: DEFAULT_ENV,
+        help: 'set the mode in which your server will run, e.g., ' +
+              '"production" or "development" (note: this will default '+
+              ' to the value of NODE_ENV environment variable if ' +
+              'present)'
+      },
+      'gracefulShutdown': {
+        full: 'graceful-shutdown',
+        metavar: '[true/false]',
+        property: true,
+        choices: ['yes', 'no', 'y', 'n', true, false, 1, 0],
+        transform: function(val) {
+          switch(val) {
+            case 'yes':
+            case 'y':
+            case true:
+            case 1:
+              return true
+              break
+            default:
+              // pass
+          }
+          return false
+        },
+        help: 'wait for all connections to terminate before exiting (note: if ' +
+              '"--env=production" this will default to "true", unless ' +
+              'explicitly specified, and "false" otherwise)  [' +
+              (DEFAULT_ENV === 'production') + ']'
+      },
+      'serverSocketTimeout': {
+        full: 'server-socket-timeout',
+        metavar: 'MSECS',
+        default: 120000,
+        property: true,
+        help: 'set the socket timeout for all incoming connections',
+        callback: function(timeout) {
+          if (parseInt(timeout) != timeout || timeout < 0) {
+            return "server-timeout must be a positive integer"
+          }
+        }
+      }
+    }
+  },
+  'gen-static-docs': {
+    command: true,
+    help: 'generate docs for the api',
+    processEnvironmentVariables: false,
+    cmdargs: {
+      flavor: {
+        default: 'github-flavored-markdown',
+        choices: ['github-flavored-markdown', 'api-blueprint', 'aglio'],
+        metavar: 'FLAVOR',
+        help: 'choose your flavor (github-flavored-markdown | api-blueprint | aglio)'
+      },
+      out: {
+        metavar: 'PATH',
+        help: 'path to write static docs to (directory for multiple pages ' +
+              '(default: api-docs) and file for single page (default: README.md))'
+      },
+      // XXX: not too happy with this. need to decide how best to represent flavor specific options
+      option: {
+        metavar: 'OPTION',
+        abbr: 'o',
+        list: true,
+        help: 'set generator specific options (format is: option[:value](,option[:value])*, can be specified multiple times)'
+      },
+      includeUndocumented: {
+        full: "include-undocumented",
+        flag: true,
+        help: "Ignore all 'noDocument' flags"
+      },
+      'show-options': {
+        flag: true,
+        help: 'show generator specific options'
+      }
+    }
+  },
+}
+
+/***************************************************************************************************
  * @class Service
  */
 var Service = oo({
@@ -433,162 +598,12 @@ var Service = oo({
    *              set of command line arguments.
    */
   defaultCmdargs: {
-    'verbosity': {
-      abbr: 'v',
-      metavar: 'VERBOSITY',
-      property: true,
-      choices: ['trace', 'debug', 'info', 'warn', 'error', 'fatal'],
-      help: 'verbosity level (trace | debug | info | warn | error | fatal)',
-    },
-    'start-server': {
-      command: true,
-      default: true,
-      help: 'start the api server',
-      cmdargs: {
-        'port': {
-          abbr: 'p',
-          metavar: 'PORT',
-          property: true,
-          help: 'port'
-        },
-        'hostname': {
-          abbr: 'n',
-          default: '0.0.0.0',   // XXX: this should probably be 127.0.0.1
-          metavar: 'HOSTNAME',
-          property: true,
-          help: 'the hostname to bind'
-        },
-        'dbUri': {
-          abbr: 'd',
-          metavar: 'DB_URI',
-          property: true,
-          help: 'MongoDB connection string'
-        },
-        'cluster': {
-          flag: true,
-          property: true,
-          help: 'use node cluster'
-        },
-        'numClusterWorkers': {
-          full: 'num-cluster-workers',
-          metavar: 'NUM',
-          property: true,
-          default: 0,
-          help: 'fork NUM cluster nodes (default is "0" to fork a worker for each CPU)'
-        },
-        'exitOnClusterWorkerExit': {
-          full: 'exit-on-cluster-worker-exit',
-          property: true,
-          flag: true,
-          help: 'if this flag is set, the master will exit if a work dies, otherwise ' +
-                'a warning will be logged'
-        },
-        'swagger': {
-          flag: true,
-          property: true,
-          help: 'mount swagger endpoints'
-        },
-        'enableBusyLimiter': {
-          full: 'enable-busy-limiter',
-          flag: true,
-          property: true,
-          help: 'send 503 responses when the node process becomes too "busy"'
-        },
-        'fiberPoolSize': {
-          full: 'fiber-pool-size',
-          metavar: 'SIZE',
-          property: true,
-          default: fibers.getFiberPoolSize(),
-          help: 'set the fiber pool size',
-          callback: function(fiberPoolSize) {
-            fiberPoolSize = parseInt(fiberPoolSize)
-            if (!_.isInteger(fiberPoolSize)) {
-              return 'fiber-pool-size must be an integer'
-            } else if (fiberPoolSize <= 0) {
-              return 'fiber-pool-size must be greater than 0'
-            }
-          }
-        },
-        'env': {
-          metavar: 'MODE',
-          property: true,
-          default: DEFAULT_ENV,
-          help: 'set the mode in which your server will run, e.g., ' +
-                '"production" or "development" (note: this will default '+
-                ' to the value of NODE_ENV environment variable if ' +
-                'present)'
-        },
-        'gracefulShutdown': {
-          full: 'graceful-shutdown',
-          metavar: '[true/false]',
-          property: true,
-          choices: ['yes', 'no', 'y', 'n', true, false, 1, 0],
-          transform: function(val) {
-            switch(val) {
-              case 'yes':
-              case 'y':
-              case true:
-              case 1:
-                return true
-                break
-              default:
-                // pass
-            }
-            return false
-          },
-          help: 'wait for all connections to terminate before exiting (note: if ' +
-                '"--env=production" this will default to "true", unless ' +
-                'explicitly specified, and "false" otherwise)  [' +
-                (DEFAULT_ENV === 'production') + ']'
-        },
-        'serverSocketTimeout': {
-          full: 'server-socket-timeout',
-          metavar: 'MSECS',
-          default: 120000,
-          property: true,
-          help: 'set the socket timeout for all incoming connections',
-          callback: function(timeout) {
-            if (parseInt(timeout) != timeout || timeout < 0) {
-              return "server-timeout must be a positive integer"
-            }
-          }
-        }
-      }
-    },
-    'gen-static-docs': {
-      command: true,
-      help: 'generate docs for the api',
-      processEnvironmentVariables: false,
-      cmdargs: {
-        flavor: {
-          default: 'github-flavored-markdown',
-          choices: ['github-flavored-markdown', 'api-blueprint', 'aglio'],
-          metavar: 'FLAVOR',
-          help: 'choose your flavor (github-flavored-markdown | api-blueprint | aglio)'
-        },
-        out: {
-          metavar: 'PATH',
-          help: 'path to write static docs to (directory for multiple pages ' +
-                '(default: api-docs) and file for single page (default: README.md))'
-        },
-        // XXX: not too happy with this. need to decide how best to represent flavor specific options
-        option: {
-          metavar: 'OPTION',
-          abbr: 'o',
-          list: true,
-          help: 'set generator specific options (format is: option[:value](,option[:value])*, can be specified multiple times)'
-        },
-        includeUndocumented: {
-          full: "include-undocumented",
-          flag: true,
-          help: "Ignore all 'noDocument' flags"
-        },
-        'show-options': {
-          flag: true,
-          help: 'show generator specific options'
-        }
-      }
-    },
+    $property: {
+      configurable: false,
+      enumerable: true,
+      writable: false,
+      value: DEFAULT_SERVICE_CMDARGS
+    }
   },
 
   // ------------------------

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -2003,7 +2003,7 @@ var Service = oo({
           }
         }
 
-        var result = operation.service(req, res)
+        var result = operation.handle(req, res)
         self.logDebug("operation.service returned: " + JSON.stringify(result))
         if (result !== undefined) {
           if (!endpoint.sanitizesOutput) {

--- a/lib/collections/Collection.js
+++ b/lib/collections/Collection.js
@@ -73,17 +73,17 @@ var Collection = oo({
     this.idGenerator = undefined
 
     /***************************************************************************
-     * @property {string} [idPathParameter] -- The PATH_ID parameter name (e.g., /collection/:PATH_ID)
+     * @property {string} [idPathParameterName] -- The PATH_ID parameter name (e.g., /collection/:PATH_ID)
      * @default {@link carbond.collections.Collection.defaultIdParameter}
      */
-    this.idPathParameter = this.defaultIdParameter
+    this.idPathParameterName = this.defaultIdParameter
 
     /***************************************************************************
-     * @property {string} [idParameter] -- The ID parameter name (XXX: rename to "objectIdName"
+     * @property {string} [idParameterName] -- The ID parameter name (XXX: rename to "objectIdName"
      *                                     since this is not a "parameter" name?)
      * @default {@link carbond.collections.Collection.defaultIdParameter}
      */
-    this.idParameter = this.defaultIdParameter
+    this.idParameterName = this.defaultIdParameter
 
     /***************************************************************************
      * @property {string} [idHeader] -- The header name which should contain the EJSON serialized ID
@@ -727,7 +727,7 @@ var Collection = oo({
    */
   _validate: function() {
     if (this.schema && !this._validateSchemaHasId(this.schema)) {
-      throw new TypeError('Schema must conain ' + this.idParameter + ', got: ' +
+      throw new TypeError('Schema must conain ' + this.idParameterName + ', got: ' +
                           ejson.stringify(this.schema))
     }
   },
@@ -739,11 +739,11 @@ var Collection = oo({
     if (schema.type === 'array') {
       // If schema is for an array, validate it's element schema
       return this._validateSchemaHasId(schema.items)
-    } else if (schema && schema.properties && schema.properties[this.idParameter] &&
-               _.includes(schema.required, this.idParameter)) {
+    } else if (schema && schema.properties && schema.properties[this.idParameterName] &&
+               _.includes(schema.required, this.idParameterName)) {
       return schema
     }
-    throw new Error('Invalid schema. ' + this.idParameter +
+    throw new Error('Invalid schema. ' + this.idParameterName +
                     ' must be a property, and must be required: ' +
                     ejson.stringify(this.schema))
   },
@@ -763,7 +763,7 @@ var Collection = oo({
       config.parameters = {[atom.OPERATORS.MERGE]: config.parameters}
     }
     config = o(config, this.getOperationConfigClass(op))
-    config.idParameter = this.idParameter
+    config.idParameterName = this.idParameterName
     return config
   },
 
@@ -955,16 +955,16 @@ var Collection = oo({
     var options = {}
 
     for (var i = 0; i < obj.length; i++) {
-      if (!_.isNil(obj[i][this.idParameter])) {
+      if (!_.isNil(obj[i][this.idParameterName])) {
         throw new this.service.errors.BadRequest(
-          '"' + this.idParameter +'" is not allowed on insert')
+          '"' + this.idParameterName +'" is not allowed on insert')
       }
     }
 
     // generate ID if a generator exists
     if (this.idGenerator) {
       obj.forEach(function(obj) {
-        obj[self.idParameter] = self.idGenerator.generateId(self, req)
+        obj[self.idParameterName] = self.idGenerator.generateId(self, req)
       })
     }
 
@@ -988,14 +988,14 @@ var Collection = oo({
     var obj = req.parameters.object
     var options = {}
 
-    if (!_.isNil(obj[this.idParameter])) {
+    if (!_.isNil(obj[this.idParameterName])) {
       throw new this.service.errors.BadRequest(
-        '"' + this.idParameter +'" is not allowed on insert')
+        '"' + this.idParameterName +'" is not allowed on insert')
     }
 
     // generate ID if a generator exists
     if (this.idGenerator) {
-      obj[self.idParameter] = self.idGenerator.generateId(self, req)
+      obj[self.idParameterName] = self.idGenerator.generateId(self, req)
     }
 
     options = _.assignIn(options, config.options, req.parameters)
@@ -1246,7 +1246,7 @@ var Collection = oo({
       '200': {
         statusCode: 200,
         description: 'Returns an array of objects. Each object has an ' +
-                     this.idParameter +
+                     this.idParameterName +
                      ' and possible additional properties.',
         schema: {
           type: 'array',
@@ -1302,14 +1302,14 @@ var Collection = oo({
     }
 
     if (config.supportsIdQuery) {
-      options[this.idParameter] = _.get(req.parameters, this.idParameter, [])
-      if (!_.isArray(options[this.idParameter])) {
-        options[this.idParameter] = [options[this.idParameter]]
+      options[this.idParameterName] = _.get(req.parameters, this.idParameterName, [])
+      if (!_.isArray(options[this.idParameterName])) {
+        options[this.idParameterName] = [options[this.idParameterName]]
       }
-      if (options[this.idParameter].length === 0) {
-        options[this.idParameter] = undefined
+      if (options[this.idParameterName].length === 0) {
+        options[this.idParameterName] = undefined
       }
-      paramDiff = paramDiff.concat([this.idParameter])
+      paramDiff = paramDiff.concat([this.idParameterName])
     }
 
     options = _.assignIn(
@@ -1557,7 +1557,7 @@ var Collection = oo({
       objectSubEndpoint.get = o({
         _type: '../Operation',
         description: config.opConfig.description ||
-                     'Find an object in this Collection by ' + this.idParameter,
+                     'Find an object in this Collection by ' + this.idParameterName,
         noDocument: config.opConfig.noDocument || false,
         parameters: config.opConfig.parameters || {},
         endpoint: objectSubEndpoint,
@@ -1566,8 +1566,8 @@ var Collection = oo({
         service: function(req, res) {
           var id = undefined
           var options = self.preFindObjectOperation(config.opConfig, req, res)
-          id = options[self.idPathParameter]
-          options = _.omit(options, self.idPathParameter)
+          id = options[self.idPathParameterName]
+          options = _.omit(options, self.idPathParameterName)
           ;({id, options} = _.assignIn(
             {id, options}, self.preFindObject(id, options) || {}))
           var result = self.findObject(
@@ -1851,17 +1851,17 @@ var Collection = oo({
    */
   preSaveObjectOperation: function(config, req, res) {
     var options = {}
-    if (_.isObjectLike(req.parameters.object[this.idParameter]) &&
-          ejson.stringify(req.parameters[this.idPathParameter]) !==
-          ejson.stringify(req.parameters.object[this.idParameter]) ||
-        !_.isObjectLike(req.parameters.object[this.idParameter]) &&
-          req.parameters[this.idPathParameter] !==
-          req.parameters.object[this.idParameter]) {
+    if (_.isObjectLike(req.parameters.object[this.idParameterName]) &&
+          ejson.stringify(req.parameters[this.idPathParameterName]) !==
+          ejson.stringify(req.parameters.object[this.idParameterName]) ||
+        !_.isObjectLike(req.parameters.object[this.idParameterName]) &&
+          req.parameters[this.idPathParameterName] !==
+          req.parameters.object[this.idParameterName]) {
       throw new this.service.errors.BadRequest(
-        'Path ' + this.idPathParameter + ' does not match object.' + this.idParameter + '.')
+        'Path ' + this.idPathParameterName + ' does not match object.' + this.idParameterName + '.')
     }
     options = _.assignIn(
-      options, _.omit(req.parameters, config.options, this.idPathParameter))
+      options, _.omit(req.parameters, config.options, this.idPathParameterName))
     return options
   },
 
@@ -1945,7 +1945,7 @@ var Collection = oo({
       objectSubEndpoint.put = o({
         _type: '../Operation',
         description: config.opConfig.description ||
-                     'Save an object in this Collection by ' + this.idPathParameter,
+                     'Save an object in this Collection by ' + this.idPathParameterName,
         noDocument: config.opConfig.noDocument || false,
         parameters: config.opConfig.parameters || {},
         responses: this._makeResponses(
@@ -2083,7 +2083,7 @@ var Collection = oo({
 
     if (config.opConfig.supportsUpsert && result.created) {
       if (!_.isArray(result.val)) {
-        throw new Error('An array of objects with at least ' + this.idParameter +
+        throw new Error('An array of objects with at least ' + this.idParameterName +
                         ' properties must be returned if "supportsUpsert" is true')
       }
       var headers = this._get201Headers(result, req)
@@ -2275,7 +2275,7 @@ var Collection = oo({
 
     if (config.opConfig.supportsUpsert && result.created) {
       if (!_.isObjectLike(result.val)) {
-        throw new Error('An object with at least ' + this.idParameter + ' property must be ' +
+        throw new Error('An object with at least ' + this.idParameterName + ' property must be ' +
                         'returned if "supportsUpsert" is true')
       }
       var headers = this._get201Headers(result, req)
@@ -2343,7 +2343,7 @@ var Collection = oo({
       objectSubEndpoint.patch = o({
         _type: '../Operation',
         description: config.opConfig.description ||
-                     'Update an object in this Collection by ' + this.idPathParameter,
+                     'Update an object in this Collection by ' + this.idPathParameterName,
         noDocument: config.opConfig.noDocument || false,
         parameters: config.opConfig.parameters || {},
         responses: this._makeResponses(
@@ -2353,9 +2353,9 @@ var Collection = oo({
           var id = undefined
           var update = undefined
           var options = self.preUpdateObjectOperation(config.opConfig, req, res)
-          id = options[self.idPathParameter]
+          id = options[self.idPathParameterName]
           update = options.update
-          options = _.omit(options, 'update', self.idPathParameter)
+          options = _.omit(options, 'update', self.idPathParameterName)
           ;({id, update, options} = _.assignIn(
             {id, update, options}, self.preUpdateObject(id, update, options) || {}))
           var result = self.updateObject(id, update, options)
@@ -2667,7 +2667,7 @@ var Collection = oo({
       objectSubEndpoint.delete = o({
         _type: '../Operation',
         description: config.opConfig.description ||
-                     'Remove an object in this Collection by ' + this.idPathParameter,
+                     'Remove an object in this Collection by ' + this.idPathParameterName,
         noDocument: config.opConfig.noDocument || false,
         parameters: config.opConfig.parameters || {},
         responses: this._makeResponses(
@@ -2676,8 +2676,8 @@ var Collection = oo({
         service: function(req, res) {
           var id = undefined
           var options = self.preRemoveObjectOperation(config.opConfig, req, res)
-          id = options[self.idPathParameter]
-          options = _.omit(options, self.idPathParameter)
+          id = options[self.idPathParameterName]
+          options = _.omit(options, self.idPathParameterName)
           ;({id, options} = _.assignIn(
             {id, options}, self.preRemoveObject(id, options) || {}))
           var result = self.removeObject(id, options)
@@ -2729,29 +2729,29 @@ var Collection = oo({
       [this.idHeader]: undefined
     }
     var _path = req.path
-    if (!_.isNil(req.parameters[this.idPathParameter]) &&
-        req.parameters[this.idPathParameter].toString() === path.basename(_path)) {
+    if (!_.isNil(req.parameters[this.idPathParameterName]) &&
+        req.parameters[this.idPathParameterName].toString() === path.basename(_path)) {
       _path = path.dirname(_path)
     }
     if (_.isArray(result.val)) {
       headers.location = url.format({
         pathname: _.trimEnd(_path, '/'),
         query: {
-          [this.idParameter]: _.map(result.val, function(obj) {
-            return obj[self.idParameter].toString()
+          [this.idParameterName]: _.map(result.val, function(obj) {
+            return obj[self.idParameterName].toString()
           })
         }
       })
       headers[this.idHeader] = ejson.stringify(
         _.map(result.val, function(obj) {
-          return obj[self.idParameter]
+          return obj[self.idParameterName]
         })
       )
     } else {
       headers.location =
         path.normalize(
-          path.join(_.trimEnd(_path, '/'), result.val[this.idParameter].toString()))
-      headers[this.idHeader] = ejson.stringify(result.val[this.idParameter])
+          path.join(_.trimEnd(_path, '/'), result.val[this.idParameterName].toString()))
+      headers[this.idHeader] = ejson.stringify(result.val[this.idParameterName])
     }
     return headers
   },
@@ -2766,7 +2766,7 @@ var Collection = oo({
     // so we move them there (except :<PATH_ID> itself)
     var childEndpoints = self.endpoints
     _.forIn(childEndpoints, function(childEndpoint, path) {
-      if (path !== ':' + self.idPathParameter) {
+      if (path !== ':' + self.idPathParameterName) {
         self._getObjectSubEndpoint().endpoints[path] = childEndpoint
         delete self.endpoints[path]
       }
@@ -2777,7 +2777,7 @@ var Collection = oo({
    * _getObjectSubEndpoint
    */
   _getObjectSubEndpoint: function() {
-    var subEndpointPath = ':' + this.idPathParameter
+    var subEndpointPath = ':' + this.idPathParameterName
     if (!this.endpoints[subEndpointPath]) {
         this.endpoints[subEndpointPath] = this._makeObjectSubEndpoint()
     }
@@ -2793,18 +2793,18 @@ var Collection = oo({
     // See if schema has a type for ID defined
     var schema = this.schema
     var idSchema = undefined
-    if (schema && schema.properties && schema.properties[this.idParameter]) {
-      idSchema = schema.properties[this.idParameter]
+    if (schema && schema.properties && schema.properties[this.idParameterName]) {
+      idSchema = schema.properties[this.idParameterName]
     }
 
     // parameters
     var parameters = {}
-    var idParameterName = this.idPathParameter[0] === ':' ?
-        this.idPathParameter.substring(1) :
-        this.idPathParameter
+    var idParameterName = this.idPathParameterName[0] === ':' ?
+        this.idPathParameterName.substring(1) :
+        this.idPathParameterName
 
     parameters[idParameterName] = {
-      description: 'Object ' + this.idParameter,
+      description: 'Object ' + this.idParameterName,
       location: 'path',
       schema: idSchema,
       required: true,
@@ -2879,7 +2879,7 @@ var Collection = oo({
         responses['404'] = {
           statusCode: 404,
           description: 'Collection resource cannot be found by the supplied ' +
-                       self.idPathParameter + '.',
+                       self.idPathParameterName + '.',
           schema: _.cloneDeep(self.defaultErrorSchema)
         }
       }

--- a/lib/collections/Collection.js
+++ b/lib/collections/Collection.js
@@ -86,10 +86,10 @@ var Collection = oo({
     this.idParameterName = this.defaultIdParameter
 
     /***************************************************************************
-     * @property {string} [idHeader] -- The header name which should contain the EJSON serialized ID
-     * @default {@link carbond.collections.Collection.defaultIdHeader}
+     * @property {string} [idHeaderName] -- The header name which should contain the EJSON serialized ID
+     * @default {@link carbond.collections.Collection.defaultIdHeaderName}
      */
-    this.idHeader = this.defaultIdHeader
+    this.idHeaderName = this.defaultIdHeaderName
 
     /***************************************************************************
      * @property {Object} [insertConfig] -- The config used to govern the behavior of the {@link insert}
@@ -227,10 +227,10 @@ var Collection = oo({
   },
 
   /*****************************************************************************
-   * @property {string} defaultIdHeader -- The default ID header name
+   * @property {string} defaultIdHeaderName -- The default ID header name
    * @readonly
    */
-  defaultIdHeader: {
+  defaultIdHeaderName: {
     $property: {
       enumerable: true,
       value: 'carbonio-id'
@@ -861,7 +861,7 @@ var Collection = oo({
         schema: config.returnsInsertedObjects ?
                   resultSchema :
                   {type: 'undefined'},
-        headers: ['Location', this.idHeader]
+        headers: ['Location', this.idHeaderName]
       }
     }
 
@@ -918,7 +918,7 @@ var Collection = oo({
         schema: config.returnsInsertedObject ?
                   resultSchema :
                   {type: 'undefined'},
-        headers: ['Location', this.idHeader]
+        headers: ['Location', this.idHeaderName]
       }
     }
 
@@ -1019,7 +1019,7 @@ var Collection = oo({
     res.status(201)
     var headers = this._get201Headers(result, req)
     res.header('Location', headers.location)
-    res.header(this.idHeader, headers[this.idHeader])
+    res.header(this.idHeaderName, headers[this.idHeaderName])
     // Must convert undefined to null for Service to know to commit
     // the response.
     return config.opConfig.returnsInsertedObjects ? result.val : null
@@ -1041,7 +1041,7 @@ var Collection = oo({
     res.status(201)
     var headers = this._get201Headers(result, req)
     res.header('Location', headers.location)
-    res.header(this.idHeader, headers[this.idHeader])
+    res.header(this.idHeaderName, headers[this.idHeaderName])
     return config.opConfig.returnsInsertedObject ? result.val : null
   },
 
@@ -1816,7 +1816,7 @@ var Collection = oo({
         schema: config.returnsSavedObject ?
                   _.cloneDeep(resultSchema) :
                   {type: 'undefined'},
-        headers: ['Location', this.idHeader]
+        headers: ['Location', this.idHeaderName]
       }
     }
 
@@ -1889,7 +1889,7 @@ var Collection = oo({
       var headers = this._get201Headers(result, req)
       res.status(201)
       res.header('Location', headers.location)
-      res.header(this.idHeader, headers[this.idHeader])
+      res.header(this.idHeaderName, headers[this.idHeaderName])
     } else if (config.opConfig.returnsSavedObject) {
       res.status(200)
     } else {
@@ -2025,7 +2025,7 @@ var Collection = oo({
                     minItems: 1
                   } :
                   _.cloneDeep(resultSchema),
-        headers: ['Location', this.idHeader]
+        headers: ['Location', this.idHeaderName]
       }
     }
 
@@ -2089,7 +2089,7 @@ var Collection = oo({
       var headers = this._get201Headers(result, req)
       res.status(201)
       res.header('Location', headers.location)
-      res.header(this.idHeader, headers[this.idHeader])
+      res.header(this.idHeaderName, headers[this.idHeaderName])
       return config.opConfig.returnsUpsertedObjects ? result.val : {n: result.val.length}
     }
     return {n: result.val}
@@ -2217,7 +2217,7 @@ var Collection = oo({
         schema: config.returnsUpsertedObject ?
                   this.schema :
                   _.cloneDeep(resultSchema),
-        headers: ['Location', this.idHeader]
+        headers: ['Location', this.idHeaderName]
       }
     }
 
@@ -2281,7 +2281,7 @@ var Collection = oo({
       var headers = this._get201Headers(result, req)
       res.status(201)
       res.header('Location', headers.location)
-      res.header(this.idHeader, headers[this.idHeader])
+      res.header(this.idHeaderName, headers[this.idHeaderName])
       return config.opConfig.returnsUpsertedObject ? result.val : {n: 1}
     }
 
@@ -2726,7 +2726,7 @@ var Collection = oo({
     var self = this
     var headers = {
       location: undefined,
-      [this.idHeader]: undefined
+      [this.idHeaderName]: undefined
     }
     var _path = req.path
     if (!_.isNil(req.parameters[this.idPathParameterName]) &&
@@ -2742,7 +2742,7 @@ var Collection = oo({
           })
         }
       })
-      headers[this.idHeader] = ejson.stringify(
+      headers[this.idHeaderName] = ejson.stringify(
         _.map(result.val, function(obj) {
           return obj[self.idParameterName]
         })
@@ -2751,7 +2751,7 @@ var Collection = oo({
       headers.location =
         path.normalize(
           path.join(_.trimEnd(_path, '/'), result.val[this.idParameterName].toString()))
-      headers[this.idHeader] = ejson.stringify(result.val[this.idParameterName])
+      headers[this.idHeaderName] = ejson.stringify(result.val[this.idParameterName])
     }
     return headers
   },

--- a/lib/collections/CollectionOperationConfig.js
+++ b/lib/collections/CollectionOperationConfig.js
@@ -37,13 +37,13 @@ module.exports = oo(_.mixin({
     this.allowUnauthenticated = false
 
     /***************************************************************************
-     * @property {string} idParameter -- The collection object id property name. Note, this
-     *                                   is configured on the top level
-     *                                   {@link carbond.collections.Collection} and set on the
-     *                                   configure during initialzation.
+     * @property {string} idParameterName -- The collection object id property name. Note, this
+     *                                       is configured on the top level
+     *                                       {@link carbond.collections.Collection} and set on the
+     *                                       configure during initialzation.
      * @readonly
      */
-    this.idParameter = undefined
+    this.idParameterName = undefined
 
     /***************************************************************************
      * @property {object.<string, carbond.OperationParameter>} parameters
@@ -88,10 +88,10 @@ module.exports = oo(_.mixin({
   _unrequireIdPropertyFromSchema: function(schema) {
     var _schema = schema.type === 'array' ? schema.items : schema
 
-    if (!_.isNil(_schema.properties) && _schema.properties[this.idParameter]) {
+    if (!_.isNil(_schema.properties) && _schema.properties[this.idParameterName]) {
       _schema = _.clone(_schema)
       if (_schema.required) {
-        _schema.required = _.difference(_schema.required, [this.idParameter])
+        _schema.required = _.difference(_schema.required, [this.idParameterName])
         if (_.isEmpty(_schema.required)) {
           delete _schema.required
         }

--- a/lib/collections/FindConfig.js
+++ b/lib/collections/FindConfig.js
@@ -89,9 +89,9 @@ var FindConfig = oo({
      * @property {carbond.OperationParameter} parameters.limit
      * @description The "limit" parameter definition (will be omitted if {@link
      *              carbond.collections.FindConfig.supportsSkipAndLimit} is ``false``)
-     * @property {carbond.OperationParameter} <this.idParameter>
+     * @property {carbond.OperationParameter} <this.idParameterName>
      * @description The id query parameter (will use
-     *              {@link carbond.collections.Collection.idParameter} as name)
+     *              {@link carbond.collections.Collection.idParameterName} as name)
      *              (will be omitted if {@link
      *              carbond.collections.FindConfig.supportsIdQuery} is ``false``)
      * @extends carbond.collections.CollectionOperationConfig.parameters
@@ -159,23 +159,23 @@ var FindConfig = oo({
     // XXX: would rather wrap this config in a Proxy object to accomplish the same thing
     //      but it doesn't seem there is a good way to do that
 
-    // set up a private instance property to track the actual value of idParameter as a
+    // set up a private instance property to track the actual value of idParameterName as a
     // data descriptor
-    Object.defineProperty(this, '__FindConfig_idParameter', {
+    Object.defineProperty(this, '__FindConfig_idParameterName', {
       configurable: false,
       enumerable: false,
       writable: true,
-      value: this.idParameter
+      value: this.idParameterName
     })
 
-    // redefine idParameter using an accessor descriptor and side effect the parameters
+    // redefine idParameterName using an accessor descriptor and side effect the parameters
     // object as a result of assignment
-    Object.defineProperty(this, 'idParameter', {
+    Object.defineProperty(this, 'idParameterName', {
       configurable: true,
       enumerable: true,
-      get: () => this.__FindConfig_idParameter,
+      get: () => this.__FindConfig_idParameterName,
       set: (value) => {
-        this.__FindConfig_idParameter = value
+        this.__FindConfig_idParameterName = value
         this._fixIdQueryParameter()
       }
     })
@@ -208,7 +208,7 @@ var FindConfig = oo({
    * @description If TMP_ID_QUERY_PARAMETER_NAME is in
    *              {@link carbond.collections.FindConfig.parameters}, then rename
    *              it to be the current value of
-   *              {@link carbond.collections.FindConfig.idParameter}
+   *              {@link carbond.collections.FindConfig.idParameterName}
    * @returns {undefined}
    */
   _fixIdQueryParameter: function() {
@@ -216,8 +216,8 @@ var FindConfig = oo({
     if (!_.isNil(idQueryParameter)) {
       delete this.parameters[TMP_ID_QUERY_PARAMETER_NAME]
       // reinitialize with correct name
-      this.parameters[this.idParameter] = o(
-        _.assign({}, idQueryParameter, {name: this.idParameter}),
+      this.parameters[this.idParameterName] = o(
+        _.assign({}, idQueryParameter, {name: this.idParameterName}),
         _o('../OperationParameter'))
     }
   }

--- a/lib/mongodb/MongoDBCollection.js
+++ b/lib/mongodb/MongoDBCollection.js
@@ -41,22 +41,22 @@ module.exports = oo({
    */
   _C: function() {
     /***************************************************************************
-     * @property {string} [idParameter='_id'] -- The ID parameter name
+     * @property {string} [idParameterName='_id'] -- The ID parameter name
      * @todo rename to "objectIdName" since this is not a "parameter" name?
      */
-    this.idParameter = '_id' // Same as Collection but we explicitly define it here)
+    this.idParameterName = '_id' // Same as Collection but we explicitly define it here)
 
     /***************************************************************************
-     * @property {string} [db] -- The database name. Note, this is only needed if
+     * @property {string} [dbName] -- The database name. Note, this is only needed if
      *                            the {@link carbond.Service} instance connects
      *                            to multiple databases
      */
-    this.db = undefined // The name of a db in this.endpoint.service.dbs XXX should be dbname?
+    this.dbName = undefined // The name of a db in this.endpoint.service.dbs
 
     /***************************************************************************
-     * @property {string} collection -- The database collection name
+     * @property {string} collectionName -- The database collection name
      */
-    this.collection = undefined
+    this.collectionName = undefined
 
     /***************************************************************************
      * @property {object} [querySchema] -- The JSON schema used to validate the
@@ -88,10 +88,6 @@ module.exports = oo({
 
     // initialize all operations
     Collection.prototype._init.call(this)
-
-    // if (_.isNil(this.db)) {
-    //   throw new Error('Database is not defined')
-    // }
 
     // XXX: note, this is side effecting operation.parameters by assigning to the
     //      original config... this should probably be changed
@@ -199,7 +195,8 @@ module.exports = oo({
   /*****************************************************************************
    * @property {carbond.mongodb.MongoDBFindObjectConfig} FindObjectConfigClass
    * @description The config class used to instantiate the
-   *              {@link carbond.mongodb.MongoDBCollection.findObject} operation config
+   *              {@link carbond.mongodb.MongoDBCollection.findObject} operation
+   *              config
    * @override
    * @readonly
    */
@@ -227,7 +224,8 @@ module.exports = oo({
   /*****************************************************************************
    * @property {carbond.mongodb.MongoDBSaveObjectConfig} SaveObjectConfigClass
    * @description The config class used to instantiate the
-   *              {@link carbond.mongodb.MongoDBCollection.saveObject} operation config
+   *              {@link carbond.mongodb.MongoDBCollection.saveObject} operation
+   *              config
    * @override
    * @readonly
    */
@@ -255,7 +253,8 @@ module.exports = oo({
   /*****************************************************************************
    * @property {carbond.mongodb.MongoDBUpdateObjectConfig} UpdateObjectConfigClass
    * @description The config class used to instantiate the
-   *              {@link carbond.mongodb.MongoDBCollection.updateObject} operation config
+   *              {@link carbond.mongodb.MongoDBCollection.updateObject} operation
+   *              config
    * @override
    * @readonly
    */
@@ -283,7 +282,8 @@ module.exports = oo({
   /*****************************************************************************
    * @property {carbond.mongodb.RemoveObjectConfig} RemoveObjectConfigClass
    * @description The config class used to instantiate the
-   *              {@link carbond.mongodb.MongoDBCollection.removeObject} operation config
+   *              {@link carbond.mongodb.MongoDBCollection.removeObject} operation
+   *              config
    * @override
    * @readonly
    */
@@ -295,16 +295,33 @@ module.exports = oo({
   },
 
   /*****************************************************************************
-   * _db // the actual db object
+   * @property {leafnode.db.DB} db
+   * @description The database object for the database that houses the collection
+   *              this instance is accessing
+   * @readonly
    */
-  _db : {
-    '$property': {
+  db: {
+    $property: {
       get: function() {
-        if (this.db) {
-          return this.service.dbs[this.db]
+        if (this.dbName) {
+          return this.service.dbs[this.dbName]
         } else {
           return this.service.db
         }
+      }
+    }
+  },
+
+  /*****************************************************************************
+   * @property {leafnode.db.Collection} collection
+   * @description The collection object for the collection this instance is
+   *              accessing
+   * @readonly
+   */
+  collection: {
+    $property: {
+      get: function() {
+        return this.db.getCollection(this.collectionName)
       }
     }
   },
@@ -335,7 +352,7 @@ module.exports = oo({
    * @throws {carbond.collections.errors.CollectionError}
    */
   insert: function(objects, options) {
-    return this._db.getCollection(this.collection).insertObjects(objects)
+    return this.collection.insertObjects(objects)
   },
 
   /******************************************************************************
@@ -364,7 +381,7 @@ module.exports = oo({
    * @throws {carbond.collections.errors.CollectionError}
    */
   insertObject: function(object, options) {
-    return this._db.getCollection(this.collection).insertObject(object, options.driverOptions)
+    return this.collection.insertObject(object, options.driverOptions)
   },
 
   // XXX: this should be removed once https://github.com/carbon-io/carbond/issues/235 is taken care of
@@ -402,20 +419,20 @@ module.exports = oo({
     if (!_.isNil(options.query)) {
       query = _.clone(options.query)
       // handle _id queries passed in "_id" query parameter
-      if (!_.isNil(options[this.idParameter])) {
-        if (_.isArray(options[this.idParameter])) {
-          if (options[this.idParameter].length > 0) {
-            query[this.idParameter] = {
-              $in: _.map(options[this.idParameter], this._parseIdQueryParameter)
+      if (!_.isNil(options[this.idParameterName])) {
+        if (_.isArray(options[this.idParameterName])) {
+          if (options[this.idParameterName].length > 0) {
+            query[this.idParameterName] = {
+              $in: _.map(options[this.idParameterName], this._parseIdQueryParameter)
             }
           }
         } else {
-          query[this.idParameter] = this._parseIdQueryParameter(options[this.idParameter])
+          query[this.idParameterName] = this._parseIdQueryParameter(options[this.idParameterName])
         }
       }
     }
     // query
-    var curs = this._db.getCollection(this.collection).find(query)
+    var curs = this.collection.find(query)
     // project
     if (!_.isNil(options.projection)) {
       curs = curs.project(options.projection)
@@ -465,7 +482,7 @@ module.exports = oo({
    * @throws {carbond.collections.errors.CollectionError}
    */
   findObject: function(id, options) {
-    return this._db.getCollection(this.collection).findOne({_id: id}, options.driverOptions)
+    return this.collection.findOne({_id: id}, options.driverOptions)
   },
 
   /*****************************************************************************
@@ -497,10 +514,10 @@ module.exports = oo({
     var result = undefined
     var renameResult = undefined
     var tmpCollectionName = uuid() + '-' + this.collection
-    var tmpCollection = this._db.getCollection(tmpCollectionName)
+    var tmpCollection = this.db.getCollection(tmpCollectionName)
     try {
       result = tmpCollection.insertMany(objects, options.driverOptions)
-      renameResult = tmpCollection.rename(this.collection, {dropTarget: true})
+      renameResult = tmpCollection.rename(this.collectionName, {dropTarget: true})
     } finally {
       if (_.isNil(renameResult)) {
         tmpCollection.drop()
@@ -542,8 +559,8 @@ module.exports = oo({
    * @throws {carbond.collections.errors.CollectionError}
    */
   saveObject: function(object, options) {
-    var result = this._db.getCollection(
-      this.collection).findOneAndReplace({_id: object._id}, object, options.driverOptions)
+    var result = this.collection.findOneAndReplace(
+      {_id: object._id}, object, options.driverOptions)
     return {
       val: result.value,
       created: options.driverOptions.upsert && !result.lastErrorObject.updatedExisting
@@ -584,7 +601,7 @@ module.exports = oo({
     var result = undefined
     try {
       var result =
-        this._db.getCollection(this.collection).updateMany(options.query, update, driverOptions)
+        this.collection.updateMany(options.query, update, driverOptions)
     } catch (e) {
       // XXX: revisit this when leafnode exposes mongo error codes
       // https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err
@@ -635,8 +652,7 @@ module.exports = oo({
       driverOptions = _.assignIn(driverOptions, options.driverOptions, {upsert: true})
     }
     // use updateOne to expose upsertedCount
-    var result =
-      this._db.getCollection( this.collection).updateOne({_id: id}, update, driverOptions)
+    var result = this.collection.updateOne({_id: id}, update, driverOptions)
     var _result = {
       // omit matchedCount here since we are counting updates
       val: result.modifiedCount + result.upsertedCount,
@@ -674,8 +690,8 @@ module.exports = oo({
    * @throws {carbond.collections.errors.CollectionError}
    */
   remove: function(options) {
-    return this._db.getCollection(
-      this.collection).deleteMany(options.query, options.driverOptions).deletedCount
+    return this.collection.deleteMany(
+      options.query, options.driverOptions).deletedCount
   },
 
   /*****************************************************************************
@@ -706,7 +722,7 @@ module.exports = oo({
    */
   removeObject: function(id, options) {
     try {
-      this._db.getCollection(this.collection).deleteObject(id, options.driverOptions)
+      this.collection.deleteObject(id, options.driverOptions)
       return 1
     } catch (e) {
       if (e instanceof leafnode.errors.LeafnodeObjectSetOperationError) {

--- a/test/collections/AdvancedCollectionTests.js
+++ b/test/collections/AdvancedCollectionTests.js
@@ -250,7 +250,7 @@ __(function() {
                                  'resource and the body will contain the inserted object if ' +
                                  'configured to do so.',
                     schema: this.parent.normalizedDefaultObjectSchema,
-                    headers: ['Location', this.parent.ce.idHeader]
+                    headers: ['Location', this.parent.ce.idHeaderName]
                   },
                   '400': this.parent.BadRequestResponse,
                   '403': this.parent.ForbiddenResponse,
@@ -313,7 +313,7 @@ __(function() {
                       required: ['n'],
                       additionalProperties: false
                     },
-                    headers: ['Location', this.parent.ce.idHeader]
+                    headers: ['Location', this.parent.ce.idHeaderName]
                   },
                   '400': this.parent.BadRequestResponse,
                   '403': this.parent.ForbiddenResponse,
@@ -375,7 +375,7 @@ __(function() {
                                  'resource and the body will contain the upserted object if ' +
                                  'configured to do so.',
                     schema: this.parent.normalizedDefaultObjectSchema,
-                    headers: ['Location', this.parent.ce.idHeader]
+                    headers: ['Location', this.parent.ce.idHeaderName]
                   },
                   '400': this.parent.BadRequestResponse,
                   '403': this.parent.ForbiddenResponse,

--- a/test/collections/BasicCollectionTests.js
+++ b/test/collections/BasicCollectionTests.js
@@ -557,7 +557,7 @@ __(function() {
                         }
                       ]
                     },
-                    headers: ['Location', this.parent.ce.defaultIdHeader]
+                    headers: ['Location', this.parent.ce.defaultIdHeaderName]
                   },
                   '400': _.assign(_.clone(this.parent.BadRequestResponse), {
                     schema: {
@@ -813,7 +813,7 @@ __(function() {
                                  'resource and the body will contain the inserted object if ' +
                                  'configured to do so.',
                     schema: this.parent.normalizedDefaultObjectSchema,
-                    headers: ['Location', this.parent.ce.idHeader]
+                    headers: ['Location', this.parent.ce.idHeaderName]
                   },
                   '400': this.parent.BadRequestResponse,
                   '403': this.parent.ForbiddenResponse,

--- a/test/collections2/CollectionAllowUnauthenticatedTests.js
+++ b/test/collections2/CollectionAllowUnauthenticatedTests.js
@@ -104,8 +104,8 @@ __(function() {
     },
     setup: function(context) {
       carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-      context.global.rejectUnauthenticatedId = this.service.endpoints.rejectUnauthenticated.idParameter
-      context.global.allowUnauthenticatedId = this.service.endpoints.allowUnauthenticated.idParameter
+      context.global.rejectUnauthenticatedId = this.service.endpoints.rejectUnauthenticated.idParameterName
+      context.global.allowUnauthenticatedId = this.service.endpoints.allowUnauthenticated.idParameterName
     },
     teardown: function(context) {
       delete context.global.rejectUnauthenticatedId
@@ -114,7 +114,7 @@ __(function() {
       carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
     },
     doTest: function() {
-      var idParameter = this.service.endpoints.allowUnauthenticated.idParameter
+      var idParameterName = this.service.endpoints.allowUnauthenticated.idParameterName
       var allMethods = _.without(carbond.Endpoint.prototype.ALL_METHODS, 'options')
       assert(_.isNil(this.service.endpoints.rejectUnauthenticated.allowUnauthenticated))
       for (var i = 0; i < allMethods; i++) {
@@ -124,7 +124,7 @@ __(function() {
       }
       for (var i = 0; i < allMethods; i++) {
         assert(_.includes(
-          this.service.endpoints.allowUnauthenticated.endpoints[idParameter].allowUnauthenticated,
+          this.service.endpoints.allowUnauthenticated.endpoints[idParameterName].allowUnauthenticated,
           allMethods[i]
         ))
       }

--- a/test/collections2/CollectionTests.js
+++ b/test/collections2/CollectionTests.js
@@ -80,8 +80,8 @@ __(function() {
                 find: true,
                 insert: true
               },
-              idParameter: 'foo',
-              idPathParameter: 'foo',
+              idParameterName: 'foo',
+              idPathParameterName: 'foo',
               schema: {
                 type: 'object',
                 properties: {
@@ -227,8 +227,8 @@ __(function() {
                 find: true,
                 findObject: true,
               },
-              idParameter: 'foo',
-              idPathParameter: 'foo',
+              idParameterName: 'foo',
+              idPathParameterName: 'foo',
               schema: {
                 type: 'object',
                 properties: {
@@ -269,8 +269,8 @@ __(function() {
                 find: true,
                 findObject: true,
               },
-              idParameter: 'bar',
-              idPathParameter: 'bar',
+              idParameterName: 'bar',
+              idPathParameterName: 'bar',
               schema: {
                 type: 'object',
                 properties: {
@@ -526,7 +526,7 @@ __(function() {
                 '*': true
               },
               idGenerator: pong.util.collectionIdGenerator,
-              idParameter: '_id',
+              idParameterName: '_id',
               schema: {
                 type: 'object',
                 properties: {
@@ -598,11 +598,11 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.foo.idParameter
+          context.global.idParameterName = this.service.endpoints.foo.idParameterName
           context.global.idHeader = this.service.endpoints.foo.idHeader
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           delete context.global.idHeader
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -629,7 +629,7 @@ __(function() {
                 additionalProperties: false
               })
               assert.equal(collection.get.responses[200].headers[0], 'foo')
-              assert.deepEqual(collection.endpoints[`:${context.global.idParameter}`].get.responses[200], {
+              assert.deepEqual(collection.endpoints[`:${context.global.idParameterName}`].get.responses[200], {
                 statusCode: 200,
                 description: 'foo bar baz',
                 schema: {
@@ -653,7 +653,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     insert: [{
-                      [context.global.idParameter]: '0',
+                      [context.global.idParameterName]: '0',
                       foo: 'bar',
                       bar: 'baz'
                     }]
@@ -666,7 +666,7 @@ __(function() {
               statusCode: 201,
               body: function(body, context) {
                 assert.deepEqual(body, [{
-                  [context.global.idParameter]: '0',
+                  [context.global.idParameterName]: '0',
                   foo: 'bar',
                   bar: 'baz'
                 }])
@@ -682,7 +682,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     insert: [{
-                      [context.global.idParameter]: '0',
+                      [context.global.idParameterName]: '0',
                       foo: 'bar',
                       bar: 'baz',
                       baz: '666'
@@ -707,7 +707,7 @@ __(function() {
                 method: 'POST',
                 headers: {
                   'x-pong': ejson.stringify({
-                    insertObject: {[context.global.idParameter]: '0'}
+                    insertObject: {[context.global.idParameterName]: '0'}
                   })
                 },
                 body: {foo: 'bar', bar: 'baz', baz: 'yaz'}
@@ -716,7 +716,7 @@ __(function() {
             resSpec: {
               statusCode: 201,
               body: function(body, context) {
-                assert.deepEqual(body, {[context.global.idParameter]: '0'})
+                assert.deepEqual(body, {[context.global.idParameterName]: '0'})
               }
             }
           },
@@ -729,7 +729,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     insertObject: {
-                      [context.global.idParameter]: '0',
+                      [context.global.idParameterName]: '0',
                       foo: 'bar',
                       bar: 'baz',
                       baz: 'yaz'
@@ -755,7 +755,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     find: [{
-                      [context.global.idParameter]: '0',
+                      [context.global.idParameterName]: '0',
                       foo: 'bar',
                       bar: 'baz',
                       baz: 'yaz'
@@ -780,7 +780,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     findObject: {
-                      [context.global.idParameter]: '0'
+                      [context.global.idParameterName]: '0'
                     }
                   })
                 }
@@ -790,7 +790,7 @@ __(function() {
               statusCode: 200,
               body: function(body, context) {
                 assert.deepEqual(body, {
-                  [context.global.idParameter]: '0'
+                  [context.global.idParameterName]: '0'
                 })
               }
             }
@@ -804,7 +804,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     findObject: {
-                      [context.global.idParameter]: '0',
+                      [context.global.idParameterName]: '0',
                       foo: 'bar'
                     }
                   })

--- a/test/collections2/CollectionTests.js
+++ b/test/collections2/CollectionTests.js
@@ -599,11 +599,11 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.foo.idParameterName
-          context.global.idHeader = this.service.endpoints.foo.idHeader
+          context.global.idHeaderName = this.service.endpoints.foo.idHeaderName
         },
         teardown: function(context) {
           delete context.global.idParameterName
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -640,7 +640,7 @@ __(function() {
                   required: ['_id'],
                   additionalProperties: false
                 },
-                headers: ['Location', context.global.idHeader]
+                headers: ['Location', context.global.idHeaderName]
               })
             }
           }),

--- a/test/collections2/findObjectTests.js
+++ b/test/collections2/findObjectTests.js
@@ -48,10 +48,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.findObject.idParameter
+          context.global.idParameterName = this.service.endpoints.findObject.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -64,7 +64,7 @@ __(function() {
                 method: 'HEAD',
                 headers: {
                   'x-pong': ejson.stringify({
-                    findObject: {[context.global.idParameter]: '0', foo: 'bar'}
+                    findObject: {[context.global.idParameterName]: '0', foo: 'bar'}
                   })
                 }
               }
@@ -83,7 +83,7 @@ __(function() {
                 method: 'GET',
                 headers: {
                   'x-pong': ejson.stringify({
-                    findObject: [{[context.global.idParameter]: '0', foo: 'bar'}]
+                    findObject: [{[context.global.idParameterName]: '0', foo: 'bar'}]
                   })
                 }
               }
@@ -101,7 +101,7 @@ __(function() {
                 method: 'GET',
                 headers: {
                   'x-pong': ejson.stringify({
-                    findObject: {[context.global.idParameter]: '0', foo: 'bar'}
+                    findObject: {[context.global.idParameterName]: '0', foo: 'bar'}
                   })
                 }
               }
@@ -109,7 +109,7 @@ __(function() {
             resSpec: {
               statusCode: 200,
               body: function(body, context) {
-                assert.deepStrictEqual(body, {[context.global.idParameter]: '0', foo: 'bar'})
+                assert.deepStrictEqual(body, {[context.global.idParameterName]: '0', foo: 'bar'})
               }
             }
           },
@@ -162,10 +162,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.findObject.idParameter
+          context.global.idParameterName = this.service.endpoints.findObject.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -174,7 +174,7 @@ __(function() {
             name: 'FindObjectConfigCustomParameterInitializationTest',
             doTest: function(context) {
               let findObjectOperation = 
-                this.parent.service.endpoints.findObject.endpoints[`:${context.global.idParameter}`].get
+                this.parent.service.endpoints.findObject.endpoints[`:${context.global.idParameterName}`].get
               assert.deepEqual(findObjectOperation.parameters, {
                 foo: {
                   name: 'foo',
@@ -202,7 +202,7 @@ __(function() {
                 method: 'GET',
                 headers: {
                   'x-pong': ejson.stringify({
-                    findObject: {[context.global.idParameter]: '0', foo: 'bar'}
+                    findObject: {[context.global.idParameterName]: '0', foo: 'bar'}
                   }),
                   foo: 3
                 }
@@ -227,7 +227,7 @@ __(function() {
                 method: 'GET',
                 headers: {
                   'x-pong': ejson.stringify({
-                    findObject: {[context.global.idParameter]: '0', foo: 'bar'}
+                    findObject: {[context.global.idParameterName]: '0', foo: 'bar'}
                   }),
                   foo: 4
                 }

--- a/test/collections2/findTests.js
+++ b/test/collections2/findTests.js
@@ -48,10 +48,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.find.idParameter
+          context.global.idParameterName = this.service.endpoints.find.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -65,9 +65,9 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     find: [
-                      {[context.global.idParameter]: '0', foo: 'bar'},
-                      {[context.global.idParameter]: '1', bar: 'baz'},
-                      {[context.global.idParameter]: '2', baz: 'yaz'}
+                      {[context.global.idParameterName]: '0', foo: 'bar'},
+                      {[context.global.idParameterName]: '1', bar: 'baz'},
+                      {[context.global.idParameterName]: '2', baz: 'yaz'}
                     ]
                   })
                 }
@@ -90,7 +90,7 @@ __(function() {
                 method: 'GET',
                 headers: {
                   'x-pong': ejson.stringify({
-                    find: {[context.global.idParameter]: '0', foo: 'bar'}
+                    find: {[context.global.idParameterName]: '0', foo: 'bar'}
                   })
                 }
               }
@@ -109,9 +109,9 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     find: [
-                      {[context.global.idParameter]: '0', foo: 'bar'},
-                      {[context.global.idParameter]: '1', bar: 'baz'},
-                      {[context.global.idParameter]: '2', baz: 'yaz'}
+                      {[context.global.idParameterName]: '0', foo: 'bar'},
+                      {[context.global.idParameterName]: '1', bar: 'baz'},
+                      {[context.global.idParameterName]: '2', baz: 'yaz'}
                     ]
                   })
                 }
@@ -124,9 +124,9 @@ __(function() {
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'},
-                  {[context.global.idParameter]: '2', baz: 'yaz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'},
+                  {[context.global.idParameterName]: '2', baz: 'yaz'}
                 ])
               }
             }
@@ -141,7 +141,7 @@ __(function() {
               try {
                 assert(this.findSpy.called)
                 assert.deepEqual(
-                  this.findSpy.firstCall.args[0][context.global.idParameter],
+                  this.findSpy.firstCall.args[0][context.global.idParameterName],
                   ['0', '1', '2'])
               } finally {
                 this.findSpy.restore()
@@ -152,14 +152,14 @@ __(function() {
                 url: '/find',
                 method: 'GET',
                 parameters: {
-                  [context.global.idParameter]: ['0', '1', '2']
+                  [context.global.idParameterName]: ['0', '1', '2']
                 },
                 headers: {
                   'x-pong': ejson.stringify({
                     find: [
-                      {[context.global.idParameter]: '0', foo: 'bar'},
-                      {[context.global.idParameter]: '1', bar: 'baz'},
-                      {[context.global.idParameter]: '2', baz: 'yaz'}
+                      {[context.global.idParameterName]: '0', foo: 'bar'},
+                      {[context.global.idParameterName]: '1', bar: 'baz'},
+                      {[context.global.idParameterName]: '2', baz: 'yaz'}
                     ]
                   })
                 }
@@ -172,9 +172,9 @@ __(function() {
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'},
-                  {[context.global.idParameter]: '2', baz: 'yaz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'},
+                  {[context.global.idParameterName]: '2', baz: 'yaz'}
                 ])
               }
             }
@@ -206,7 +206,7 @@ __(function() {
                 },
                 headers: {
                   'x-pong': ejson.stringify({
-                    find: [{[context.global.idParameter]: '0', foo: 'bar'}]
+                    find: [{[context.global.idParameterName]: '0', foo: 'bar'}]
                   })
                 }
               }
@@ -217,7 +217,7 @@ __(function() {
                 assert(_.isNil(headers.link))
               },
               body: function(body, context) {
-                assert.deepStrictEqual(body, [{[context.global.idParameter]: '0', foo: 'bar'}])
+                assert.deepStrictEqual(body, [{[context.global.idParameterName]: '0', foo: 'bar'}])
               }
             }
           },
@@ -241,10 +241,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.find.idParameter
+          context.global.idParameterName = this.service.endpoints.find.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -256,7 +256,7 @@ __(function() {
             },
             teardown: function(context) {
               try {
-                assert(!(context.global.idParameter in this.findSpy.firstCall.args[0]))
+                assert(!(context.global.idParameterName in this.findSpy.firstCall.args[0]))
               } finally {
                 this.findSpy.restore()
               }
@@ -266,7 +266,7 @@ __(function() {
                 url: '/find',
                 method: 'GET',
                 parameters: {
-                  [context.global.idParameter]: 0
+                  [context.global.idParameterName]: 0
                 },
                 headers: {
                   'x-pong': ejson.stringify({
@@ -414,10 +414,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.find.idParameter
+          context.global.idParameterName = this.service.endpoints.find.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -454,8 +454,8 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     find: [
-                      {[context.global.idParameter]: '6', foo: 'bar'},
-                      {[context.global.idParameter]: '7', bar: 'baz'}
+                      {[context.global.idParameterName]: '6', foo: 'bar'},
+                      {[context.global.idParameterName]: '7', bar: 'baz'}
                     ]
                   })
                 }
@@ -470,8 +470,8 @@ __(function() {
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '6', foo: 'bar'},
-                  {[context.global.idParameter]: '7', bar: 'baz'}
+                  {[context.global.idParameterName]: '6', foo: 'bar'},
+                  {[context.global.idParameterName]: '7', bar: 'baz'}
                 ])
               }
             }
@@ -502,8 +502,8 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     find: [
-                      {[context.global.idParameter]: '0', foo: 'bar'},
-                      {[context.global.idParameter]: '1', bar: 'baz'}
+                      {[context.global.idParameterName]: '0', foo: 'bar'},
+                      {[context.global.idParameterName]: '1', bar: 'baz'}
                     ]
                   })
                 }
@@ -518,8 +518,8 @@ __(function() {
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'}
                 ])
               }
             }
@@ -553,7 +553,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     find: [
-                      {[context.global.idParameter]: '4', foo: 'bar'}
+                      {[context.global.idParameterName]: '4', foo: 'bar'}
                     ]
                   })
                 }
@@ -568,7 +568,7 @@ __(function() {
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '4', foo: 'bar'},
+                  {[context.global.idParameterName]: '4', foo: 'bar'},
                 ])
               }
             }
@@ -599,7 +599,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     find: [
-                      {[context.global.idParameter]: '0', foo: 'bar'}
+                      {[context.global.idParameterName]: '0', foo: 'bar'}
                     ]
                   })
                 }
@@ -612,7 +612,7 @@ __(function() {
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
                 ])
               }
             }
@@ -647,7 +647,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     find: _.map(_.range(this.parent.service.endpoints.find.findConfig.maxPageSize), function(n) {
-                      return {[context.global.idParameter]: n.toString(), foo: 'bar'}
+                      return {[context.global.idParameterName]: n.toString(), foo: 'bar'}
                     })
                   })
                 }
@@ -687,7 +687,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     find: _.map(_.range(this.parent.service.endpoints.find.findConfig.maxPageSize) + 1, function(n) {
-                      return {[context.global.idParameter]: n.toString(), foo: 'bar'}
+                      return {[context.global.idParameterName]: n.toString(), foo: 'bar'}
                     })
                   })
                 }
@@ -725,7 +725,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     find: _.map(_.range(5), function(n) {
-                      return {[context.global.idParameter]: n.toString(), foo: 'bar'}
+                      return {[context.global.idParameterName]: n.toString(), foo: 'bar'}
                     })
                   })
                 }
@@ -766,10 +766,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.find.idParameter
+          context.global.idParameterName = this.service.endpoints.find.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -787,8 +787,8 @@ __(function() {
                   required: false,
                   default: undefined
                 },
-                [context.global.idParameter]: {
-                  name: context.global.idParameter,
+                [context.global.idParameterName]: {
+                  name: context.global.idParameterName,
                   location: 'query',
                   description: carbond.collections.FindConfig._STRINGS.parameters.idParameterDefinition.description,
                   schema: {
@@ -818,7 +818,7 @@ __(function() {
                 method: 'GET',
                 headers: {
                   'x-pong': ejson.stringify({
-                    find: [{[context.global.idParameter]: '0', foo: 'bar'}]
+                    find: [{[context.global.idParameterName]: '0', foo: 'bar'}]
                   }),
                   foo: 3
                 }
@@ -843,7 +843,7 @@ __(function() {
                 method: 'GET',
                 headers: {
                   'x-pong': ejson.stringify({
-                    find: [{[context.global.idParameter]: '0', foo: 'bar'}]
+                    find: [{[context.global.idParameterName]: '0', foo: 'bar'}]
                   }),
                   foo: 4
                 }

--- a/test/collections2/insertObjectTests.js
+++ b/test/collections2/insertObjectTests.js
@@ -49,11 +49,11 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.insertObject.idParameterName
-          context.global.idHeader = this.service.endpoints.insertObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.insertObject.idHeaderName
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -96,7 +96,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify('0'))
                 assert.deepStrictEqual(headers.location, '/insertObject/0')
               },
@@ -183,11 +183,11 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.insertObject.idParameterName
-          context.global.idHeader = this.service.endpoints.insertObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.insertObject.idHeaderName
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -229,7 +229,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify('0'))
                 assert.deepStrictEqual(
                   headers.location, this.reqSpec.url + '/0')
@@ -294,11 +294,11 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.insertObject.idParameterName
-          context.global.idHeader = this.service.endpoints.insertObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.insertObject.idHeaderName
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -325,7 +325,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify('0'))
                 assert.deepStrictEqual(
                   headers.location, '/insertObject/0')
@@ -365,11 +365,11 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.insertObject.idParameterName
-          context.global.idHeader = this.service.endpoints.insertObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.insertObject.idHeaderName
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },

--- a/test/collections2/insertObjectTests.js
+++ b/test/collections2/insertObjectTests.js
@@ -48,13 +48,13 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.insertObject.idParameter
+          context.global.idParameterName = this.service.endpoints.insertObject.idParameterName
           context.global.idHeader = this.service.endpoints.insertObject.idHeader
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -102,7 +102,7 @@ __(function() {
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, {
-                  [context.global.idParameter]: '0',
+                  [context.global.idParameterName]: '0',
                   foo: 'bar'
                 })
               }
@@ -123,7 +123,7 @@ __(function() {
                     insertObject: {$args: 0}
                   })
                 },
-                body: {[context.global.idParameter]: '0', foo: 'bar'}
+                body: {[context.global.idParameterName]: '0', foo: 'bar'}
               }
             },
             resSpec: {
@@ -182,13 +182,13 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.insertObject.idParameter
+          context.global.idParameterName = this.service.endpoints.insertObject.idParameterName
           context.global.idHeader = this.service.endpoints.insertObject.idHeader
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -236,7 +236,7 @@ __(function() {
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, {
-                  [context.global.idParameter]: '0', foo: 'bar'
+                  [context.global.idParameterName]: '0', foo: 'bar'
                 })
               }
             }
@@ -293,13 +293,13 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.insertObject.idParameter
+          context.global.idParameterName = this.service.endpoints.insertObject.idParameterName
           context.global.idHeader = this.service.endpoints.insertObject.idHeader
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -364,13 +364,13 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.insertObject.idParameter
+          context.global.idParameterName = this.service.endpoints.insertObject.idParameterName
           context.global.idHeader = this.service.endpoints.insertObject.idHeader
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [

--- a/test/collections2/insertTests.js
+++ b/test/collections2/insertTests.js
@@ -48,13 +48,13 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.insert.idParameter
+          context.global.idParameterName = this.service.endpoints.insert.idParameterName
           context.global.idHeader = this.service.endpoints.insert.idHeader
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -98,11 +98,11 @@ __(function() {
                   ejson.stringify(['0']))
                 assert.deepStrictEqual(
                   headers.location,
-                  url.format({pathname: '/insert', query: {[context.global.idParameter]: '0'}}))
+                  url.format({pathname: '/insert', query: {[context.global.idParameterName]: '0'}}))
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, [{
-                  [context.global.idParameter]: '0',
+                  [context.global.idParameterName]: '0',
                   foo: 'bar'
                 }])
               }
@@ -135,13 +135,13 @@ __(function() {
                 assert.deepStrictEqual(
                   headers.location,
                   url.format(
-                    {pathname: '/insert', query: {[context.global.idParameter]: ['0', '1', '2']}}))
+                    {pathname: '/insert', query: {[context.global.idParameterName]: ['0', '1', '2']}}))
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'},
-                  {[context.global.idParameter]: '2', baz: 'yaz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'},
+                  {[context.global.idParameterName]: '2', baz: 'yaz'}
                 ])
               }
             }
@@ -161,7 +161,7 @@ __(function() {
                     insert: {$args: 0}
                   })
                 },
-                body: [{[context.global.idParameter]: '0', foo: 'bar'}]
+                body: [{[context.global.idParameterName]: '0', foo: 'bar'}]
               }
             },
             resSpec: {
@@ -184,9 +184,9 @@ __(function() {
                   })
                 },
                 body: [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'},
-                  {[context.global.idParameter]: '2', baz: 'yaz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'},
+                  {[context.global.idParameterName]: '2', baz: 'yaz'}
                 ]
               }
             },
@@ -247,13 +247,13 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.insert.idParameter
+          context.global.idParameterName = this.service.endpoints.insert.idParameterName
           context.global.idHeader = this.service.endpoints.insert.idHeader
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -299,13 +299,13 @@ __(function() {
                 assert.deepStrictEqual(
                   headers.location,
                   url.format(
-                    {pathname: this.reqSpec.url, query: {[context.global.idParameter]: ['0', '1', '2']}}))
+                    {pathname: this.reqSpec.url, query: {[context.global.idParameterName]: ['0', '1', '2']}}))
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', '666': 'bar'},
-                  {[context.global.idParameter]: '2', '777': 'baz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', '666': 'bar'},
+                  {[context.global.idParameterName]: '2', '777': 'baz'}
                 ])
               }
             }
@@ -360,13 +360,13 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.insert.idParameter
+          context.global.idParameterName = this.service.endpoints.insert.idParameterName
           context.global.idHeader = this.service.endpoints.insert.idHeader
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -396,7 +396,7 @@ __(function() {
                   ejson.stringify(['0']))
                 assert.deepStrictEqual(
                   headers.location,
-                  url.format({pathname: '/insert', query: {[context.global.idParameter]: '0'}}))
+                  url.format({pathname: '/insert', query: {[context.global.idParameterName]: '0'}}))
               },
               body: undefined
             }
@@ -428,7 +428,7 @@ __(function() {
                 assert.deepStrictEqual(
                   headers.location,
                   url.format(
-                    {pathname: '/insert', query: {[context.global.idParameter]: ['0', '1', '2']}}))
+                    {pathname: '/insert', query: {[context.global.idParameterName]: ['0', '1', '2']}}))
               },
               body: undefined
             }
@@ -464,13 +464,13 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.insert.idParameter
+          context.global.idParameterName = this.service.endpoints.insert.idParameterName
           context.global.idHeader = this.service.endpoints.insert.idHeader
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [

--- a/test/collections2/insertTests.js
+++ b/test/collections2/insertTests.js
@@ -49,11 +49,11 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.insert.idParameterName
-          context.global.idHeader = this.service.endpoints.insert.idHeader
+          context.global.idHeaderName = this.service.endpoints.insert.idHeaderName
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -94,7 +94,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify(['0']))
                 assert.deepStrictEqual(
                   headers.location,
@@ -130,7 +130,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify(['0', '1', '2']))
                 assert.deepStrictEqual(
                   headers.location,
@@ -248,11 +248,11 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.insert.idParameterName
-          context.global.idHeader = this.service.endpoints.insert.idHeader
+          context.global.idHeaderName = this.service.endpoints.insert.idHeaderName
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -294,7 +294,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify(['0', '1', '2']))
                 assert.deepStrictEqual(
                   headers.location,
@@ -361,11 +361,11 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.insert.idParameterName
-          context.global.idHeader = this.service.endpoints.insert.idHeader
+          context.global.idHeaderName = this.service.endpoints.insert.idHeaderName
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -392,7 +392,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify(['0']))
                 assert.deepStrictEqual(
                   headers.location,
@@ -423,7 +423,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify(['0', '1', '2']))
                 assert.deepStrictEqual(
                   headers.location,
@@ -465,11 +465,11 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.insert.idParameterName
-          context.global.idHeader = this.service.endpoints.insert.idHeader
+          context.global.idHeaderName = this.service.endpoints.insert.idHeaderName
         },
         teardown: function(context) {
           pong.util.collectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },

--- a/test/collections2/removeObjectTests.js
+++ b/test/collections2/removeObjectTests.js
@@ -47,10 +47,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.removeObject.idParameter
+          context.global.idParameterName = this.service.endpoints.removeObject.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -124,7 +124,7 @@ __(function() {
                 method: 'DELETE',
                 headers: {
                   'x-pong': ejson.stringify({
-                    removeObject: {[context.global.idParameter]: '0', foo: 'bar'}
+                    removeObject: {[context.global.idParameterName]: '0', foo: 'bar'}
                   })
                 }
               }
@@ -152,10 +152,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.removeObject.idParameter
+          context.global.idParameterName = this.service.endpoints.removeObject.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -168,7 +168,7 @@ __(function() {
                 method: 'DELETE',
                 headers: {
                   'x-pong': ejson.stringify({
-                    removeObject: {[context.global.idParameter]: '0', foo: 'bar'}
+                    removeObject: {[context.global.idParameterName]: '0', foo: 'bar'}
                   })
                 }
               }
@@ -176,7 +176,7 @@ __(function() {
             resSpec: {
               statusCode: 200,
               body: function(body, context) {
-                assert.deepStrictEqual(body, {[context.global.idParameter]: '0', foo: 'bar'})
+                assert.deepStrictEqual(body, {[context.global.idParameterName]: '0', foo: 'bar'})
               }
             }
           },
@@ -233,7 +233,7 @@ __(function() {
                 method: 'DELETE',
                 headers: {
                   'x-pong': ejson.stringify({
-                    removeObject: [{[context.global.idParameter]: '0', foo: 'bar'}]
+                    removeObject: [{[context.global.idParameterName]: '0', foo: 'bar'}]
                   })
                 }
               }
@@ -273,10 +273,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.removeObject.idParameter
+          context.global.idParameterName = this.service.endpoints.removeObject.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -285,7 +285,7 @@ __(function() {
             name: 'RemoveObjectConfigCustomParameterInitializationTest',
             doTest: function(context) {
               let removeObjectOperation = 
-                this.parent.service.endpoints.removeObject.endpoints[`:${context.global.idParameter}`].delete
+                this.parent.service.endpoints.removeObject.endpoints[`:${context.global.idParameterName}`].delete
               assert.deepEqual(removeObjectOperation.parameters, {
                 foo: {
                   name: 'foo',

--- a/test/collections2/removeTests.js
+++ b/test/collections2/removeTests.js
@@ -47,10 +47,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.remove.idParameter
+          context.global.idParameterName = this.service.endpoints.remove.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -124,7 +124,7 @@ __(function() {
                 method: 'DELETE',
                 headers: {
                   'x-pong': ejson.stringify({
-                    remove: [{[context.global.idParameter]: '0', foo: 'bar'}]
+                    remove: [{[context.global.idParameterName]: '0', foo: 'bar'}]
                   })
                 }
               }
@@ -152,10 +152,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.remove.idParameter
+          context.global.idParameterName = this.service.endpoints.remove.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -169,9 +169,9 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     remove: [
-                      {[context.global.idParameter]: '0', foo: 'bar'},
-                      {[context.global.idParameter]: '1', bar: 'baz'},
-                      {[context.global.idParameter]: '2', baz: 'yaz'}
+                      {[context.global.idParameterName]: '0', foo: 'bar'},
+                      {[context.global.idParameterName]: '1', bar: 'baz'},
+                      {[context.global.idParameterName]: '2', baz: 'yaz'}
                     ]
                   })
                 }
@@ -181,9 +181,9 @@ __(function() {
               statusCode: 200,
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'},
-                  {[context.global.idParameter]: '2', baz: 'yaz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'},
+                  {[context.global.idParameterName]: '2', baz: 'yaz'}
                 ])
               }
             }
@@ -241,7 +241,7 @@ __(function() {
                 method: 'DELETE',
                 headers: {
                   'x-pong': ejson.stringify({
-                    remove: {[context.global.idParameter]: '0', foo: 'bar'}
+                    remove: {[context.global.idParameterName]: '0', foo: 'bar'}
                   })
                 }
               }

--- a/test/collections2/saveObjectTests.js
+++ b/test/collections2/saveObjectTests.js
@@ -49,10 +49,10 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.saveObject.idParameterName
-          context.global.idHeader = this.service.endpoints.saveObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.saveObject.idHeaderName
         },
         teardown: function(context) {
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -122,7 +122,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify('0'))
                 assert.deepStrictEqual(headers.location, '/saveObject/0')
               },
@@ -290,10 +290,10 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.saveObject.idParameterName
-          context.global.idHeader = this.service.endpoints.saveObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.saveObject.idHeaderName
         },
         teardown: function(context) {
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },

--- a/test/collections2/saveObjectTests.js
+++ b/test/collections2/saveObjectTests.js
@@ -48,12 +48,12 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.saveObject.idParameter
+          context.global.idParameterName = this.service.endpoints.saveObject.idParameterName
           context.global.idHeader = this.service.endpoints.saveObject.idHeader
         },
         teardown: function(context) {
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -65,9 +65,9 @@ __(function() {
                 url: '/saveObject/0',
                 method: 'PUT',
                 body: [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'},
-                  {[context.global.idParameter]: '2', baz: 'yaz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'},
+                  {[context.global.idParameterName]: '2', baz: 'yaz'}
                 ]
               }
             },
@@ -87,14 +87,14 @@ __(function() {
                     saveObject: {$args: 0}
                   })
                 },
-                body: {[context.global.idParameter]: '0', foo: 'bar'}
+                body: {[context.global.idParameterName]: '0', foo: 'bar'}
               }
             },
             resSpec: {
               statusCode: 200,
               body: function(body, context) {
                 assert.deepStrictEqual(body, {
-                  [context.global.idParameter]: '0',
+                  [context.global.idParameterName]: '0',
                   foo: 'bar'
                 })
               }
@@ -115,7 +115,7 @@ __(function() {
                     }
                   })
                 },
-                body: {[context.global.idParameter]: '0', foo: 'bar'}
+                body: {[context.global.idParameterName]: '0', foo: 'bar'}
               }
             },
             resSpec: {
@@ -128,7 +128,7 @@ __(function() {
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, {
-                  [context.global.idParameter]: '0',
+                  [context.global.idParameterName]: '0',
                   foo: 'bar'
                 })
               }
@@ -190,10 +190,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.saveObject.idParameter
+          context.global.idParameterName = this.service.endpoints.saveObject.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -207,7 +207,7 @@ __(function() {
               return {
                 url: '/saveObject/0',
                 method: 'PUT',
-                body: {[context.global.idParameter]: '0', bar: 'baz'}
+                body: {[context.global.idParameterName]: '0', bar: 'baz'}
               }
             },
             resSpec: {
@@ -229,14 +229,14 @@ __(function() {
                     saveObject: {$args: 0}
                   })
                 },
-                body: {[context.global.idParameter]: '0', foo: 'bar'}
+                body: {[context.global.idParameterName]: '0', foo: 'bar'}
               }
             },
             resSpec: {
               statusCode: 200,
               body: function(body, context) {
                 assert.deepStrictEqual(body, {
-                  [context.global.idParameter]: '0', foo: 'bar'
+                  [context.global.idParameterName]: '0', foo: 'bar'
                 })
               }
             }
@@ -289,12 +289,12 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.saveObject.idParameter
+          context.global.idParameterName = this.service.endpoints.saveObject.idParameterName
           context.global.idHeader = this.service.endpoints.saveObject.idHeader
         },
         teardown: function(context) {
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -310,7 +310,7 @@ __(function() {
                     saveObject: {$args: 0}
                   })
                 },
-                body: {[context.global.idParameter]: '0', foo: 'bar'}
+                body: {[context.global.idParameterName]: '0', foo: 'bar'}
               }
             },
             resSpec: {
@@ -349,10 +349,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.saveObject.idParameter
+          context.global.idParameterName = this.service.endpoints.saveObject.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -361,7 +361,7 @@ __(function() {
             name: 'SaveObjectConfigCustomParameterInitializationTest',
             doTest: function(context) {
               let saveObjectOperation =
-                this.parent.service.endpoints.saveObject.endpoints[`:${context.global.idParameter}`].put
+                this.parent.service.endpoints.saveObject.endpoints[`:${context.global.idParameterName}`].put
               assert.deepEqual(saveObjectOperation.parameters, {
                 object: {
                   name: 'object',
@@ -407,7 +407,7 @@ __(function() {
                   }),
                   foo: 3
                 },
-                body: {[context.global.idParameter]: '0', foo: 'bar'}
+                body: {[context.global.idParameterName]: '0', foo: 'bar'}
               }
             },
             resSpec: {
@@ -433,7 +433,7 @@ __(function() {
                   }),
                   foo: 4
                 },
-                body: {[context.global.idParameter]: '0', foo: 'bar'}
+                body: {[context.global.idParameterName]: '0', foo: 'bar'}
               }
             },
             resSpec: {

--- a/test/collections2/saveTests.js
+++ b/test/collections2/saveTests.js
@@ -48,10 +48,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.save.idParameter
+          context.global.idParameterName = this.service.endpoints.save.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -67,7 +67,7 @@ __(function() {
                     save: {$args: 0}
                   })
                 },
-                body: {[context.global.idParameter]: '0', foo: 'bar'}
+                body: {[context.global.idParameterName]: '0', foo: 'bar'}
               }
             },
             resSpec: {
@@ -87,7 +87,7 @@ __(function() {
                   })
                 },
                 body: [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
                 ]
               }
             },
@@ -95,7 +95,7 @@ __(function() {
               statusCode: 200,
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
                 ])
               }
             }
@@ -113,9 +113,9 @@ __(function() {
                   })
                 },
                 body: [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'},
-                  {[context.global.idParameter]: '2', baz: 'yaz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'},
+                  {[context.global.idParameterName]: '2', baz: 'yaz'}
                 ]
               }
             },
@@ -123,9 +123,9 @@ __(function() {
               statusCode: 200,
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'},
-                  {[context.global.idParameter]: '2', baz: 'yaz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'},
+                  {[context.global.idParameterName]: '2', baz: 'yaz'}
                 ])
               }
             }
@@ -230,10 +230,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.save.idParameter
+          context.global.idParameterName = this.service.endpoints.save.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -245,9 +245,9 @@ __(function() {
                 url: '/save',
                 method: 'PUT',
                 body: [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'},
-                  {[context.global.idParameter]: '2', foo: 'bur'},
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'},
+                  {[context.global.idParameterName]: '2', foo: 'bur'},
                 ]
               }
             },
@@ -268,9 +268,9 @@ __(function() {
                   })
                 },
                 body: [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', '666': 'bar'},
-                  {[context.global.idParameter]: '2', '777': 'baz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', '666': 'bar'},
+                  {[context.global.idParameterName]: '2', '777': 'baz'}
                 ]
               }
             },
@@ -278,9 +278,9 @@ __(function() {
               statusCode: 200,
               body: function(body, context) {
                 assert.deepStrictEqual(body, [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', '666': 'bar'},
-                  {[context.global.idParameter]: '2', '777': 'baz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', '666': 'bar'},
+                  {[context.global.idParameterName]: '2', '777': 'baz'}
                 ])
               }
             }
@@ -333,10 +333,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.save.idParameter
+          context.global.idParameterName = this.service.endpoints.save.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -353,7 +353,7 @@ __(function() {
                   })
                 },
                 body: [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
                 ]
               }
             },
@@ -375,9 +375,9 @@ __(function() {
                   })
                 },
                 body: [
-                  {[context.global.idParameter]: '0', foo: 'bar'},
-                  {[context.global.idParameter]: '1', bar: 'baz'},
-                  {[context.global.idParameter]: '2', baz: 'yaz'}
+                  {[context.global.idParameterName]: '0', foo: 'bar'},
+                  {[context.global.idParameterName]: '1', bar: 'baz'},
+                  {[context.global.idParameterName]: '2', baz: 'yaz'}
                 ]
               }
             },
@@ -417,10 +417,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.save.idParameter
+          context.global.idParameterName = this.service.endpoints.save.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -439,11 +439,11 @@ __(function() {
                     items: {
                       type: 'object',
                       properties: {
-                        [context.global.idParameter]: {
+                        [context.global.idParameterName]: {
                           type: 'string'
                         }
                       },
-                      required: [context.global.idParameter],
+                      required: [context.global.idParameterName],
                       additionalProperties: true
                     }
                   },
@@ -480,7 +480,7 @@ __(function() {
                   }),
                   foo: 3
                 },
-                body: [{[context.global.idParameter]: '0', foo: 'bar'}]
+                body: [{[context.global.idParameterName]: '0', foo: 'bar'}]
               }
             },
             resSpec: {
@@ -506,7 +506,7 @@ __(function() {
                   }),
                   foo: 4
                 },
-                body: [{[context.global.idParameter]: '0', foo: 'bar'}]
+                body: [{[context.global.idParameterName]: '0', foo: 'bar'}]
               }
             },
             resSpec: {

--- a/test/collections2/updateObjectTests.js
+++ b/test/collections2/updateObjectTests.js
@@ -332,10 +332,10 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.updateObject.idParameterName
-          context.global.idHeader = this.service.endpoints.updateObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.updateObject.idHeaderName
         },
         teardown: function(context) {
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -389,7 +389,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(headers.location, '/updateObject/0')
-                assert.deepStrictEqual(headers[context.global.idHeader], '"0"')
+                assert.deepStrictEqual(headers[context.global.idHeaderName], '"0"')
               },
               body: {n: 1}
             }
@@ -453,10 +453,10 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.updateObject.idParameterName
-          context.global.idHeader = this.service.endpoints.updateObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.updateObject.idHeaderName
         },
         teardown: function(context) {
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -512,7 +512,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(headers.location, '/updateObject/0')
-                assert.deepStrictEqual(headers[context.global.idHeader], '"0"')
+                assert.deepStrictEqual(headers[context.global.idHeaderName], '"0"')
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, {[context.global.idParameterName]: '0', foo: 'bar'})

--- a/test/collections2/updateObjectTests.js
+++ b/test/collections2/updateObjectTests.js
@@ -331,12 +331,12 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.updateObject.idParameter
+          context.global.idParameterName = this.service.endpoints.updateObject.idParameterName
           context.global.idHeader = this.service.endpoints.updateObject.idHeader
         },
         teardown: function(context) {
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -375,7 +375,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     updateObject: {
-                      val: {[context.global.idParameter]: '0'},
+                      val: {[context.global.idParameterName]: '0'},
                       created: true
                     }
                   })
@@ -452,12 +452,12 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.updateObject.idParameter
+          context.global.idParameterName = this.service.endpoints.updateObject.idParameterName
           context.global.idHeader = this.service.endpoints.updateObject.idHeader
         },
         teardown: function(context) {
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -471,7 +471,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     updateObject: {
-                      val: {[context.global.idParameter]: '0', foo: 'bar'},
+                      val: {[context.global.idParameterName]: '0', foo: 'bar'},
                       created: true
                     }
                   })
@@ -498,7 +498,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     updateObject: {
-                      val: {[context.global.idParameter]: '0', foo: 'bar'},
+                      val: {[context.global.idParameterName]: '0', foo: 'bar'},
                       created: true
                     }
                   })
@@ -515,7 +515,7 @@ __(function() {
                 assert.deepStrictEqual(headers[context.global.idHeader], '"0"')
               },
               body: function(body, context) {
-                assert.deepStrictEqual(body, {[context.global.idParameter]: '0', foo: 'bar'})
+                assert.deepStrictEqual(body, {[context.global.idParameterName]: '0', foo: 'bar'})
               }
             }
           },
@@ -588,10 +588,10 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.updateObject.idParameter
+          context.global.idParameterName = this.service.endpoints.updateObject.idParameterName
         },
         teardown: function(context) {
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -600,7 +600,7 @@ __(function() {
             name: 'UpdateObjectConfigCustomParameterInitializationTest',
             doTest: function(context) {
               let updateObjectOperation =
-                this.parent.service.endpoints.updateObject.endpoints[`:${context.global.idParameter}`].patch
+                this.parent.service.endpoints.updateObject.endpoints[`:${context.global.idParameterName}`].patch
               assert.deepEqual(updateObjectOperation.parameters, {
                 update: {
                   name: 'update',

--- a/test/collections2/updateTests.js
+++ b/test/collections2/updateTests.js
@@ -292,12 +292,12 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.update.idParameter
+          context.global.idParameterName = this.service.endpoints.update.idParameterName
           context.global.idHeader = this.service.endpoints.update.idHeader
         },
         teardown: function(context) {
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -336,7 +336,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     update: {
-                      val: [{[context.global.idParameter]: '0'}],
+                      val: [{[context.global.idParameterName]: '0'}],
                       created: true
                     }
                   })
@@ -349,7 +349,7 @@ __(function() {
             resSpec: {
               statusCode: 201,
               headers: function(headers, context) {
-                assert.deepStrictEqual(headers.location, '/update?' + context.global.idParameter + '=0')
+                assert.deepStrictEqual(headers.location, '/update?' + context.global.idParameterName + '=0')
                 assert.deepStrictEqual(headers[context.global.idHeader], '["0"]')
               },
               body: {n: 1}
@@ -402,12 +402,12 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idParameter = this.service.endpoints.update.idParameter
+          context.global.idParameterName = this.service.endpoints.update.idParameterName
           context.global.idHeader = this.service.endpoints.update.idHeader
         },
         teardown: function(context) {
           delete context.global.idHeader
-          delete context.global.idParameter
+          delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -421,7 +421,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     update: {
-                      val: [{[context.global.idParameter]: '0', foo: 'bar'}],
+                      val: [{[context.global.idParameterName]: '0', foo: 'bar'}],
                       created: true
                     }
                   })
@@ -448,7 +448,7 @@ __(function() {
                 headers: {
                   'x-pong': ejson.stringify({
                     update: {
-                      val: [{[context.global.idParameter]: '0', foo: 'bar'}],
+                      val: [{[context.global.idParameterName]: '0', foo: 'bar'}],
                       created: true
                     }
                   })
@@ -461,11 +461,11 @@ __(function() {
             resSpec: {
               statusCode: 201,
               headers: function(headers, context) {
-                assert.deepStrictEqual(headers.location, '/update?' + context.global.idParameter + '=0')
+                assert.deepStrictEqual(headers.location, '/update?' + context.global.idParameterName + '=0')
                 assert.deepStrictEqual(headers[context.global.idHeader], '["0"]')
               },
               body: function(body, context) {
-                assert.deepStrictEqual(body, [{[context.global.idParameter]: '0', foo: 'bar'}])
+                assert.deepStrictEqual(body, [{[context.global.idParameterName]: '0', foo: 'bar'}])
               }
             }
           },

--- a/test/collections2/updateTests.js
+++ b/test/collections2/updateTests.js
@@ -293,10 +293,10 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.update.idParameterName
-          context.global.idHeader = this.service.endpoints.update.idHeader
+          context.global.idHeaderName = this.service.endpoints.update.idHeaderName
         },
         teardown: function(context) {
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -350,7 +350,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(headers.location, '/update?' + context.global.idParameterName + '=0')
-                assert.deepStrictEqual(headers[context.global.idHeader], '["0"]')
+                assert.deepStrictEqual(headers[context.global.idHeaderName], '["0"]')
               },
               body: {n: 1}
             }
@@ -403,10 +403,10 @@ __(function() {
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
           context.global.idParameterName = this.service.endpoints.update.idParameterName
-          context.global.idHeader = this.service.endpoints.update.idHeader
+          context.global.idHeaderName = this.service.endpoints.update.idHeaderName
         },
         teardown: function(context) {
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           delete context.global.idParameterName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
@@ -462,7 +462,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(headers.location, '/update?' + context.global.idParameterName + '=0')
-                assert.deepStrictEqual(headers[context.global.idHeader], '["0"]')
+                assert.deepStrictEqual(headers[context.global.idHeaderName], '["0"]')
               },
               body: function(body, context) {
                 assert.deepStrictEqual(body, [{[context.global.idParameterName]: '0', foo: 'bar'}])

--- a/test/fixtures/ServiceForCollectionTests1.js
+++ b/test/fixtures/ServiceForCollectionTests1.js
@@ -52,7 +52,7 @@ module.exports = o.main({
         var self = this
         return _.map(_.range(context.limit), function(id) {
           return {
-            [self.idParameter]: (context.skip + id).toString(),
+            [self.idParameterName]: (context.skip + id).toString(),
             op: 'find',
             context: context
           }

--- a/test/fixtures/ServiceForCollectionTests2.js
+++ b/test/fixtures/ServiceForCollectionTests2.js
@@ -141,7 +141,7 @@ module.exports = o({
                 additionalProperties: true
               }
             },
-            headers: ['Location', this.idHeader]
+            headers: ['Location', this.idHeaderName]
           }
         ],
         returnsInsertedObjects: true

--- a/test/fixtures/ServiceForMongoDBCollectionTests.js
+++ b/test/fixtures/ServiceForMongoDBCollectionTests.js
@@ -21,7 +21,7 @@ module.exports = o({
     // Simple endpoint with Collection operations defined as functions
     zipcodes: o({
       _type: carbond.mongodb.MongoDBCollection,
-      collection: 'zipcodes',
+      collectionName: 'zipcodes',
       enabled: {
         '*': true
       },
@@ -78,7 +78,7 @@ module.exports = o({
     }),
     'bag-of-props': o({
       _type: carbond.mongodb.MongoDBCollection,
-      collection: 'bag-of-props',
+      collectionName: 'bag-of-props',
 
       enabled: {
         '*': true

--- a/test/limiter/ServiceIntegrationTests.js
+++ b/test/limiter/ServiceIntegrationTests.js
@@ -37,7 +37,7 @@ var CountDownLimiter = oo({
 
 var SimpleOperation = oo({
   _type: Operation,
-  service: function() {
+  handle: function() {
     return this.endpoint.path + '::' + this.name
   }
 })

--- a/test/mongodb/MongoDBCollectionTests.js
+++ b/test/mongodb/MongoDBCollectionTests.js
@@ -38,8 +38,8 @@ __(function() {
      */
     setup: function(ctx) {
       carbond.test.ServiceTest.prototype.setup.call(this, ctx)
-      this.idHeader = ctx.global.idHeader
-      ctx.global.idHeader = this.service.endpoints.zipcodes.idHeader
+      this.idHeaderName = ctx.global.idHeaderName
+      ctx.global.idHeaderName = this.service.endpoints.zipcodes.idHeaderName
       this.initializeDatabase(this.service.db)
     },
 
@@ -48,7 +48,7 @@ __(function() {
      */
     teardown: function(ctx) {
       this.clearDatabase(this.service.db)
-      ctx.global.idHeader = this.idHeader
+      ctx.global.idHeaderName = this.idHeaderName
       carbond.test.ServiceTest.prototype.teardown.call(this, ctx)
     },
 
@@ -286,7 +286,7 @@ __(function() {
           statusCode: 201,
           headers: function(headers, ctx) {
             assert.equal(headers.location, '/zipcodes?_id=94114')
-            assert.deepStrictEqual(ejson.parse(headers[ctx.global.idHeader]), ['94114'])
+            assert.deepStrictEqual(ejson.parse(headers[ctx.global.idHeaderName]), ['94114'])
           },
           body: [{
             _id: '94114',
@@ -400,7 +400,7 @@ __(function() {
           statusCode: 201,
           headers: function(headers, ctx) {
             assert.equal(headers.location, '/zipcodes/94114')
-            assert.equal(ejson.parse(headers[ctx.global.idHeader]), '94114')
+            assert.equal(ejson.parse(headers[ctx.global.idHeaderName]), '94114')
           },
           body: {_id: '94114', state: 'CA'}
         }
@@ -415,7 +415,7 @@ __(function() {
           statusCode: 200,
           headers: function(headers, ctx) {
             assert(_.isUndefined(headers.location))
-            assert(_.isUndefined(headers[ctx.global.idHeader]))
+            assert(_.isUndefined(headers[ctx.global.idHeaderName]))
           },
           body: {_id: '94114', state: 'CA'}
         }
@@ -432,7 +432,7 @@ __(function() {
           statusCode: 200,
           headers: function(headers, ctx) {
             assert(_.isUndefined(headers.location))
-            assert(_.isUndefined(headers[ctx.global.idHeader]))
+            assert(_.isUndefined(headers[ctx.global.idHeaderName]))
           },
           body: {n: 1}
         }
@@ -687,7 +687,7 @@ __(function() {
                         }
                       ]
                     },
-                    headers: ['Location', this.parent.ce.idHeader]
+                    headers: ['Location', this.parent.ce.idHeaderName]
                   },
                   '400': _.assign(_.clone(this.parent.BadRequestResponse), {
                     schema: {
@@ -1070,7 +1070,7 @@ __(function() {
                                  'resource and the body will contain the inserted object if ' +
                                  'configured to do so.',
                     schema: this.parent.schema,
-                    headers: ['Location', this.parent.ce.idHeader]
+                    headers: ['Location', this.parent.ce.idHeaderName]
                   },
                   '400': this.parent.BadRequestResponse,
                   '403': this.parent.ForbiddenResponse,

--- a/test/mongodb/MongoDBCollectionTests.js
+++ b/test/mongodb/MongoDBCollectionTests.js
@@ -263,7 +263,7 @@ __(function() {
           try {
             var collection = this.parent.service.endpoints.zipcodes
             var dbObject =
-              collection._db.getCollection(collection.collection).findOne({
+              collection.collection.findOne({
                 _id: '94114'
               })
             assert(!_.isNil(dbObject))

--- a/test/mongodb2/findObjectTests.js
+++ b/test/mongodb2/findObjectTests.js
@@ -47,7 +47,7 @@ __(function() {
             findObject: o({
               _type: pong.MongoDBCollection,
               enabled: {findObject: true},
-              collection: 'findObject'
+              collectionName: 'findObject'
             })
           }
         }),

--- a/test/mongodb2/findTests.js
+++ b/test/mongodb2/findTests.js
@@ -47,7 +47,7 @@ __(function() {
             find: o({
               _type: pong.MongoDBCollection,
               enabled: {find: true},
-              collection: 'find'
+              collectionName: 'find'
             })
           }
         }),
@@ -257,7 +257,7 @@ __(function() {
             find: o({
               _type: pong.MongoDBCollection,
               enabled: {find: true},
-              collection: 'find',
+              collectionName: 'find',
               findConfig: {
                 pageSize: 4,
                 maxPageSize: 8
@@ -398,7 +398,7 @@ __(function() {
             find: o({
               _type: pong.MongoDBCollection,
               enabled: {find: true},
-              collection: 'find',
+              collectionName: 'find',
               findConfig: {
                 supportsIdQuery: false
               }
@@ -442,7 +442,7 @@ __(function() {
             find: o({
               _type: pong.MongoDBCollection,
               enabled: {find: true},
-              collection: 'find',
+              collectionName: 'find',
               findConfig: {
                 supportsSkipAndLimit: false
               }
@@ -492,7 +492,7 @@ __(function() {
             find: o({
               _type: pong.MongoDBCollection,
               enabled: {find: true},
-              collection: 'find',
+              collectionName: 'find',
               findConfig: {
                 supportsPagination: false
               }
@@ -562,7 +562,7 @@ __(function() {
             find: o({
               _type: pong.MongoDBCollection,
               enabled: {find: true},
-              collection: 'find',
+              collectionName: 'find',
               querySchema: {
                 type: 'object',
                 properties: {
@@ -577,7 +577,7 @@ __(function() {
             find1: o({
               _type: pong.MongoDBCollection,
               enabled: {find: true},
-              collection: 'find',
+              collectionName: 'find',
               findConfig: {
                 '$parameters.query.schema': {
                   type: 'object',
@@ -594,7 +594,7 @@ __(function() {
             find2: o({
               _type: pong.MongoDBCollection,
               enabled: {find: true},
-              collection: 'find',
+              collectionName: 'find',
               querySchema: {
                 type: 'object',
                 properties: {

--- a/test/mongodb2/insertObjectTests.js
+++ b/test/mongodb2/insertObjectTests.js
@@ -48,7 +48,7 @@ __(function() {
               _type: pong.MongoDBCollection,
               idGenerator: pong.util.mongoDbCollectionIdGenerator,
               enabled: {insertObject: true},
-              collection: 'insertObject'
+              collectionName: 'insertObject'
             })
           }
         }),
@@ -136,7 +136,7 @@ __(function() {
               _type: pong.MongoDBCollection,
               idGenerator: pong.util.mongoDbCollectionIdGenerator,
               enabled: {insertObject: true},
-              collection: 'insertObject',
+              collectionName: 'insertObject',
               insertObjectConfig: {
                 insertObjectSchema: {
                   type: 'object',
@@ -224,7 +224,7 @@ __(function() {
               _type: pong.MongoDBCollection,
               idGenerator: pong.util.mongoDbCollectionIdGenerator,
               enabled: {insertObject: true},
-              collection: 'insertObject',
+              collectionName: 'insertObject',
               insertObjectConfig: {
                 returnsInsertedObject: false
               }

--- a/test/mongodb2/insertObjectTests.js
+++ b/test/mongodb2/insertObjectTests.js
@@ -54,11 +54,11 @@ __(function() {
         }),
         setup: function(context) {
           MongoDBCollectionHttpTest.prototype.setup.apply(this, arguments)
-          context.global.idHeader = this.service.endpoints.insertObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.insertObject.idHeaderName
         },
         teardown: function(context) {
           pong.util.mongoDbCollectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           MongoDBCollectionHttpTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -96,7 +96,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify(getObjectId(0)))
                 assert.deepStrictEqual(
                   headers.location, '/insertObject/' + getObjectId(0).toString())
@@ -157,11 +157,11 @@ __(function() {
         }),
         setup: function(context) {
           MongoDBCollectionHttpTest.prototype.setup.apply(this, arguments)
-          context.global.idHeader = this.service.endpoints.insertObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.insertObject.idHeaderName
         },
         teardown: function(context) {
           pong.util.mongoDbCollectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           MongoDBCollectionHttpTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -199,7 +199,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify(getObjectId(0)))
                 assert.deepStrictEqual(
                   headers.location, '/insertObject/' + getObjectId(0).toString())
@@ -233,11 +233,11 @@ __(function() {
         }),
         setup: function(context) {
           MongoDBCollectionHttpTest.prototype.setup.apply(this, arguments)
-          context.global.idHeader = this.service.endpoints.insertObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.insertObject.idHeaderName
         },
         teardown: function(context) {
           pong.util.mongoDbCollectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           MongoDBCollectionHttpTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -258,7 +258,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify(getObjectId(0)))
                 assert.deepStrictEqual(
                   headers.location, '/insertObject/' + getObjectId(0).toString())

--- a/test/mongodb2/insertTests.js
+++ b/test/mongodb2/insertTests.js
@@ -61,11 +61,11 @@ __(function() {
         }),
         setup: function(context) {
           MongoDBCollectionHttpTest.prototype.setup.apply(this, arguments)
-          context.global.idHeader = this.service.endpoints.insert.idHeader
+          context.global.idHeaderName = this.service.endpoints.insert.idHeaderName
         },
         teardown: function(context) {
           pong.util.mongoDbCollectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           MongoDBCollectionHttpTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -101,7 +101,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify([getObjectId(0)]))
                 assert.deepEqual(
                   headers.location,
@@ -133,7 +133,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify([getObjectId(0), getObjectId(1), getObjectId(2)]))
                 assert.deepEqual(
                   headers.location,
@@ -226,11 +226,11 @@ __(function() {
         }),
         setup: function(context) {
           MongoDBCollectionHttpTest.prototype.setup.apply(this, arguments)
-          context.global.idHeader = this.service.endpoints.insert.idHeader
+          context.global.idHeaderName = this.service.endpoints.insert.idHeaderName
         },
         teardown: function(context) {
           pong.util.mongoDbCollectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           MongoDBCollectionHttpTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -268,7 +268,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify([getObjectId(0), getObjectId(1), getObjectId(2)]))
                 assert.deepStrictEqual(
                   headers.location,
@@ -309,11 +309,11 @@ __(function() {
         }),
         setup: function(context) {
           carbond.test.ServiceTest.prototype.setup.apply(this, arguments)
-          context.global.idHeader = this.service.endpoints.insert.idHeader
+          context.global.idHeaderName = this.service.endpoints.insert.idHeaderName
         },
         teardown: function(context) {
           pong.util.mongoDbCollectionIdGenerator.resetId()
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           carbond.test.ServiceTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -339,7 +339,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify([getObjectId(0)]))
                 assert.deepStrictEqual(
                   headers.location,
@@ -365,7 +365,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify([getObjectId(0), getObjectId(1), getObjectId(2)]))
                 assert.deepStrictEqual(
                   headers.location,

--- a/test/mongodb2/insertTests.js
+++ b/test/mongodb2/insertTests.js
@@ -55,7 +55,7 @@ __(function() {
               _type: pong.MongoDBCollection,
               idGenerator: pong.util.mongoDbCollectionIdGenerator,
               enabled: {insert: true},
-              collection: 'insert'
+              collectionName: 'insert'
             })
           }
         }),
@@ -205,7 +205,7 @@ __(function() {
               dbUri: config.MONGODB_URI + '/insert',
               idGenerator: pong.util.mongoDbCollectionIdGenerator,
               enabled: {insert: true},
-              collection: 'insert',
+              collectionName: 'insert',
               insertConfig: {
                 insertSchema: {
                   type: 'object',
@@ -300,7 +300,7 @@ __(function() {
               _type: pong.MongoDBCollection,
               idGenerator: pong.util.mongoDbCollectionIdGenerator,
               enabled: {insert: true},
-              collection: 'insert',
+              collectionName: 'insert',
               insertConfig: {
                 returnsInsertedObjects: false
               }

--- a/test/mongodb2/removeObjectTests.js
+++ b/test/mongodb2/removeObjectTests.js
@@ -47,7 +47,7 @@ __(function() {
             removeObject: o({
               _type: pong.MongoDBCollection,
               enabled: {removeObject: true},
-              collection: 'removeObject'
+              collectionName: 'removeObject'
             })
           }
         }),
@@ -86,7 +86,7 @@ __(function() {
                 removeObject: o({
                   _type: pong.MongoDBCollection,
                   enabled: {removeObject: true},
-                  collection: 'removeObject',
+                  collectionName: 'removeObject',
                   removeObjectConfig: {
                     returnsRemovedObject: true
                   }

--- a/test/mongodb2/removeTests.js
+++ b/test/mongodb2/removeTests.js
@@ -47,7 +47,7 @@ __(function() {
             remove: o({
               _type: pong.MongoDBCollection,
               enabled: {remove: true},
-              collection: 'remove'
+              collectionName: 'remove'
             })
           }
         }),
@@ -107,7 +107,7 @@ __(function() {
             remove: o({
               _type: pong.MongoDBCollection,
               enabled: {remove: true},
-              collection: 'remove',
+              collectionName: 'remove',
               removeConfig: {
                 supportsQuery: false
               }
@@ -155,7 +155,7 @@ __(function() {
                 remove: o({
                   _type: pong.MongoDBCollection,
                   enabled: {remove: true},
-                  collection: 'remove',
+                  collectionName: 'remove',
                   removeConfig: {
                     returnsRemovedObjects: true
                   }
@@ -175,7 +175,7 @@ __(function() {
             remove: o({
               _type: pong.MongoDBCollection,
               enabled: {remove: true},
-              collection: 'remove',
+              collectionName: 'remove',
               querySchema: {
                 type: 'object',
                 properties: {
@@ -190,7 +190,7 @@ __(function() {
             remove1: o({
               _type: pong.MongoDBCollection,
               enabled: {remove: true},
-              collection: 'remove',
+              collectionName: 'remove',
               removeConfig: {
                 '$parameters.query.schema': {
                   type: 'object',
@@ -207,7 +207,7 @@ __(function() {
             remove2: o({
               _type: pong.MongoDBCollection,
               enabled: {remove: true},
-              collection: 'remove',
+              collectionName: 'remove',
               querySchema: {
                 type: 'object',
                 properties: {

--- a/test/mongodb2/saveObjectTests.js
+++ b/test/mongodb2/saveObjectTests.js
@@ -47,7 +47,7 @@ __(function() {
             saveObject: o({
               _type: pong.MongoDBCollection,
               enabled: {saveObject: true},
-              collection: 'saveObject'
+              collectionName: 'saveObject'
             })
           }
         }),
@@ -132,7 +132,7 @@ __(function() {
             saveObject: o({
               _type: pong.MongoDBCollection,
               enabled: {saveObject: true},
-              collection: 'saveObject',
+              collectionName: 'saveObject',
               saveObjectConfig: {
                 saveObjectSchema: {
                   type: 'object',
@@ -191,7 +191,7 @@ __(function() {
             saveObject: o({
               _type: pong.MongoDBCollection,
               enabled: {saveObject: true},
-              collection: 'saveObject',
+              collectionName: 'saveObject',
               saveObjectConfig: {
                 returnsSavedObject: false
               }

--- a/test/mongodb2/saveObjectTests.js
+++ b/test/mongodb2/saveObjectTests.js
@@ -53,10 +53,10 @@ __(function() {
         }),
         setup: function(context) {
           MongoDBCollectionHttpTest.prototype.setup.apply(this, arguments)
-          context.global.idHeader = this.service.endpoints.saveObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.saveObject.idHeaderName
         },
         teardown: function(context) {
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           MongoDBCollectionHttpTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -109,7 +109,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(
-                  headers[context.global.idHeader],
+                  headers[context.global.idHeaderName],
                   ejson.stringify(getObjectId(0)))
                 assert.deepStrictEqual(
                   headers.location, '/saveObject/' + getObjectId(0).toString())

--- a/test/mongodb2/saveTests.js
+++ b/test/mongodb2/saveTests.js
@@ -47,7 +47,7 @@ __(function() {
             save: o({
               _type: pong.MongoDBCollection,
               enabled: {save: true},
-              collection: 'save'
+              collectionName: 'save'
             })
           }
         }),
@@ -134,7 +134,7 @@ __(function() {
             save: o({
               _type: pong.MongoDBCollection,
               enabled: {save: true},
-              collection: 'save',
+              collectionName: 'save',
               saveConfig: {
                 saveSchema: {
                   type: 'object',
@@ -206,7 +206,7 @@ __(function() {
             save: o({
               _type: pong.MongoDBCollection,
               enabled: {save: true},
-              collection: 'save',
+              collectionName: 'save',
               saveConfig: {
                 returnsSavedObjects: false
               }

--- a/test/mongodb2/updateObjectTests.js
+++ b/test/mongodb2/updateObjectTests.js
@@ -47,7 +47,7 @@ __(function() {
             updateObject: o({
               _type: pong.MongoDBCollection,
               enabled: {updateObject: true},
-              collection: 'updateObject'
+              collectionName: 'updateObject'
             })
           }
         }),
@@ -122,7 +122,7 @@ __(function() {
             updateObject: o({
               _type: pong.MongoDBCollection,
               enabled: {updateObject: true},
-              collection: 'updateObject',
+              collectionName: 'updateObject',
               updateObjectConfig: {
                 supportsUpsert: true
               }
@@ -172,7 +172,7 @@ __(function() {
             updateObject: o({
               _type: pong.MongoDBCollection,
               enabled: {updateObject: true},
-              collection: 'updateObject',
+              collectionName: 'updateObject',
               updateObjectSchema: {
                 type: 'object',
                 properties: {
@@ -192,7 +192,7 @@ __(function() {
             updateObject1: o({
               _type: pong.MongoDBCollection,
               enabled: {updateObject: true},
-              collection: 'updateObject',
+              collectionName: 'updateObject',
               updateObjectConfig: {
                 '$parameters.update.schema': {
                   type: 'object',
@@ -214,7 +214,7 @@ __(function() {
             updateObject2: o({
               _type: pong.MongoDBCollection,
               enabled: {updateObject: true},
-              collection: 'updateObject',
+              collectionName: 'updateObject',
               updateObjectSchema: {
                 type: 'object',
                 properties: {

--- a/test/mongodb2/updateObjectTests.js
+++ b/test/mongodb2/updateObjectTests.js
@@ -131,10 +131,10 @@ __(function() {
         }),
         setup: function(context) {
           MongoDBCollectionHttpTest.prototype.setup.apply(this, arguments)
-          context.global.idHeader = this.service.endpoints.updateObject.idHeader
+          context.global.idHeaderName = this.service.endpoints.updateObject.idHeaderName
         },
         teardown: function(context) {
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           MongoDBCollectionHttpTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -155,7 +155,7 @@ __(function() {
               statusCode: 201,
               headers: function(headers, context) {
                 assert.deepStrictEqual(headers.location, '/updateObject/' + getObjectId(666).toString())
-                assert.deepStrictEqual(headers[context.global.idHeader], ejson.stringify(getObjectId(666)))
+                assert.deepStrictEqual(headers[context.global.idHeaderName], ejson.stringify(getObjectId(666)))
               },
               body: {n: 1}
             }

--- a/test/mongodb2/updateTests.js
+++ b/test/mongodb2/updateTests.js
@@ -134,10 +134,10 @@ __(function() {
         }),
         setup: function(context) {
           MongoDBCollectionHttpTest.prototype.setup.apply(this, arguments)
-          context.global.idHeader = this.service.endpoints.update.idHeader
+          context.global.idHeaderName = this.service.endpoints.update.idHeaderName
         },
         teardown: function(context) {
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           MongoDBCollectionHttpTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -174,7 +174,7 @@ __(function() {
                   context.local._id = new ejson.types.ObjectId(parsedLocation.query._id)
                 })
                 assert.deepEqual(
-                  ejson.parse(headers[context.global.idHeader]),
+                  ejson.parse(headers[context.global.idHeaderName]),
                   [context.local._id])
               },
               body: {n: 1}
@@ -231,10 +231,10 @@ __(function() {
         },
         setup: function(context) {
           MongoDBCollectionHttpTest.prototype.setup.apply(this, arguments)
-          context.global.idHeader = this.service.endpoints.update.idHeader
+          context.global.idHeaderName = this.service.endpoints.update.idHeaderName
         },
         teardown: function(context) {
-          delete context.global.idHeader
+          delete context.global.idHeaderName
           MongoDBCollectionHttpTest.prototype.teardown.apply(this, arguments)
         },
         tests: [
@@ -296,7 +296,7 @@ __(function() {
             resSpec: {
               statusCode: 201,
               headers: function(headers, context) {
-                context.local._id = ejson.parse(headers[context.global.idHeader])[0]
+                context.local._id = ejson.parse(headers[context.global.idHeaderName])[0]
               },
               body: {n: 1}
             }

--- a/test/mongodb2/updateTests.js
+++ b/test/mongodb2/updateTests.js
@@ -47,7 +47,7 @@ __(function() {
             update: o({
               _type: pong.MongoDBCollection,
               enabled: {update: true},
-              collection: 'update'
+              collectionName: 'update'
             })
           }
         }),
@@ -125,7 +125,7 @@ __(function() {
             update: o({
               _type: pong.MongoDBCollection,
               enabled: {update: true},
-              collection: 'update',
+              collectionName: 'update',
               updateConfig: {
                 supportsUpsert: true
               }
@@ -194,7 +194,7 @@ __(function() {
                 update: o({
                   _type: pong.MongoDBCollection,
                   enabled: {update: true},
-                  collection: 'update',
+                  collectionName: 'update',
                   updateConfig: {
                     supportsUpsert: true,
                     returnsUpsertedObjects: true
@@ -215,7 +215,7 @@ __(function() {
             update: o({
               _type: pong.MongoDBCollection,
               enabled: {update: true},
-              collection: 'update',
+              collectionName: 'update',
               updateConfig: {
                 supportsUpsert: true
               }
@@ -318,7 +318,7 @@ __(function() {
             update: o({
               _type: pong.MongoDBCollection,
               enabled: {update: true},
-              collection: 'update',
+              collectionName: 'update',
               querySchema: {
                 type: 'object',
                 properties: {
@@ -333,7 +333,7 @@ __(function() {
             update1: o({
               _type: pong.MongoDBCollection,
               enabled: {update: true},
-              collection: 'update',
+              collectionName: 'update',
               updateConfig: {
                 '$parameters.query.schema': {
                   type: 'object',
@@ -350,7 +350,7 @@ __(function() {
             update2: o({
               _type: pong.MongoDBCollection,
               enabled: {update: true},
-              collection: 'update',
+              collectionName: 'update',
               querySchema: {
                 type: 'object',
                 properties: {
@@ -526,7 +526,7 @@ __(function() {
             update: o({
               _type: pong.MongoDBCollection,
               enabled: {update: true},
-              collection: 'update',
+              collectionName: 'update',
               updateSchema: {
                 type: 'object',
                 properties: {
@@ -546,7 +546,7 @@ __(function() {
             update1: o({
               _type: pong.MongoDBCollection,
               enabled: {update: true},
-              collection: 'update',
+              collectionName: 'update',
               updateConfig: {
                 '$parameters.update.schema': {
                   type: 'object',
@@ -568,7 +568,7 @@ __(function() {
             update2: o({
               _type: pong.MongoDBCollection,
               enabled: {update: true},
-              collection: 'update',
+              collectionName: 'update',
               updateSchema: {
                 type: 'object',
                 properties: {


### PR DESCRIPTION
rename:

`Collection.idParameter` -> `Collection.idParameterName`
`Collection.idPathParameter` -> `Collection.idPathParameterName`
`Collection.idHeader` -> `Collection.idHeaderName`
`MongoDBCollection.collection` -> `MongoDBCollection.collectionName`
`MongoDBCollection.db` -> `MongoDBCollection.dbName`

added:

`MongoDBCollection.collection` - the collection object
`MongoDBCollection.db` - the database object