### PR TITLE
Update request 2.81.0 -> 2.85.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "heap": "0.2.x",
     "lodash": "4.15.x",
     "on-finished": "2.3.x",
-    "request": "2.81.0",
+    "request": "2.85.x",
     "server-destroy": "1.0.x",
     "toobusy-js": "~0.5.1",
     "uuid": "3.0.x",


### PR DESCRIPTION
request@2.85.0 depends on hoek@4.2.1 which contains a backported fix for CVE-2018-3728